### PR TITLE
Implement workflow determinism check

### DIFF
--- a/lib/cadence/errors.rb
+++ b/lib/cadence/errors.rb
@@ -5,6 +5,10 @@ module Cadence
   # Superclass for errors specific to Cadence worker itself
   class InternalError < Error; end
 
+  # Indicates a non-deterministic workflow execution, might be due to
+  # a non-deterministic workflow implementation or the gem's bug
+  class NonDeterministicWorkflowError < InternalError; end
+
   # Superclass for misconfiguration/misuse on the client (user) side
   class ClientError < Error; end
 

--- a/lib/cadence/workflow/history/event_target.rb
+++ b/lib/cadence/workflow/history/event_target.rb
@@ -69,6 +69,10 @@ module Cadence
         def hash
           [id, type].hash
         end
+
+        def to_s
+          "#{type} (#{id})"
+        end
       end
     end
   end


### PR DESCRIPTION
This change will ensure that when a workflow is replayed all the decision match previously made ones and will raise `Cadence:: NonDeterministicWorkflowError` if not