### PR TITLE
[Fix] Cast StartTimer timeout to Integer

### DIFF
--- a/lib/cadence/version.rb
+++ b/lib/cadence/version.rb
@@ -1,3 +1,3 @@
 module Cadence
-  VERSION = '0.0.1-pre36'.freeze
+  VERSION = '0.0.1-pre37'.freeze
 end

--- a/lib/cadence/workflow/serializer/start_timer.rb
+++ b/lib/cadence/workflow/serializer/start_timer.rb
@@ -10,7 +10,7 @@ module Cadence
             startTimerDecisionAttributes:
               CadenceThrift::StartTimerDecisionAttributes.new(
                 timerId: object.timer_id.to_s,
-                startToFireTimeoutSeconds: object.timeout
+                startToFireTimeoutSeconds: object.timeout.to_i
               )
           )
         end


### PR DESCRIPTION
When supplied with anything other than Integer it will fail to serialize a Thrift message