### PR TITLE
Add sleep_until to local workflow context

### DIFF
--- a/lib/cadence/testing/local_workflow_context.rb
+++ b/lib/cadence/testing/local_workflow_context.rb
@@ -128,6 +128,11 @@ module Cadence
         ::Kernel.sleep timeout
       end
 
+      def sleep_until(end_time)
+        delay = (end_time.to_time - now).to_i
+        sleep(delay) if delay > 0
+      end
+
       def start_timer(timeout, timer_id = nil)
         raise NotImplementedError, 'not yet available for testing'
       end

--- a/lib/cadence/version.rb
+++ b/lib/cadence/version.rb
@@ -1,3 +1,3 @@
 module Cadence
-  VERSION = '0.0.1-pre38'.freeze
+  VERSION = '0.0.1-pre39'.freeze
 end


### PR DESCRIPTION
Otherwise tests will fail.