### PR TITLE
[Feature] Add workflow termination call

### DIFF
--- a/lib/cadence.rb
+++ b/lib/cadence.rb
@@ -87,6 +87,16 @@ module Cadence
       response.runId
     end
 
+    def terminate_workflow(domain, workflow_id, run_id, reason: 'manual termination', details: nil)
+      client.terminate_workflow_execution(
+        domain: domain,
+        workflow_id: workflow_id,
+        run_id: run_id,
+        reason: reason,
+        details: details
+      )
+    end
+
     def fetch_workflow_execution_info(domain, workflow_id, run_id)
       response = client.describe_workflow_execution(
         domain: domain,

--- a/lib/cadence/client/thrift_client.rb
+++ b/lib/cadence/client/thrift_client.rb
@@ -256,8 +256,18 @@ module Cadence
         send_request('ResetWorkflowExecution', request)
       end
 
-      def terminate_workflow_execution
-        raise NotImplementedError
+      def terminate_workflow_execution(domain:, workflow_id:, run_id:, reason:, details: nil)
+        request = CadenceThrift::TerminateWorkflowExecutionRequest.new(
+          domain: domain,
+          workflowExecution: CadenceThrift::WorkflowExecution.new(
+            workflowId: workflow_id,
+            runId: run_id
+          ),
+          reason: reason,
+          details: JSON.serialize(details),
+          identity: identity
+        )
+        send_request('TerminateWorkflowExecution', request)
       end
 
       def list_open_workflow_executions

--- a/spec/unit/lib/cadence_spec.rb
+++ b/spec/unit/lib/cadence_spec.rb
@@ -224,6 +224,44 @@ describe Cadence do
       end
     end
 
+    describe '.terminate_workflow' do
+      before { allow(client).to receive(:terminate_workflow_execution).and_return(nil) }
+
+      it 'terminates workflow execution' do
+        described_class.terminate_workflow('test-domain', 'xxx', 'yyy')
+
+        expect(client)
+          .to have_received(:terminate_workflow_execution)
+          .with(
+            domain: 'test-domain',
+            workflow_id: 'xxx',
+            run_id: 'yyy',
+            reason: 'manual termination',
+            details: nil
+          )
+      end
+
+      it 'terminates workflow execution with extra details' do
+        described_class.terminate_workflow(
+          'test-domain',
+          'xxx',
+          'yyy',
+          reason: 'test reason',
+          details: '{ "foo": "bar" }'
+        )
+
+        expect(client)
+          .to have_received(:terminate_workflow_execution)
+          .with(
+            domain: 'test-domain',
+            workflow_id: 'xxx',
+            run_id: 'yyy',
+            reason: 'test reason',
+            details: '{ "foo": "bar" }'
+          )
+      end
+    end
+
     describe '.fetch_workflow_execution_info' do
       let(:response) do
         instance_double(


### PR DESCRIPTION
Exposing an API call for workflow termination. This call will immediately stop workflow execution halting any running activities, timers, etc.