### PR TITLE
Make polling TTL and thread pools configurable

### DIFF
--- a/examples/bin/worker
+++ b/examples/bin/worker
@@ -7,7 +7,7 @@ Dir[File.expand_path('../workflows/*.rb', __dir__)].each { |f| require f }
 Dir[File.expand_path('../activities/*.rb', __dir__)].each { |f| require f }
 Dir[File.expand_path('../middleware/*.rb', __dir__)].each { |f| require f }
 
-worker = Cadence::Worker.new
+worker = Cadence::Worker.new(polling_ttl: 10, thread_pool_size: 20)
 
 worker.register_workflow(AsyncActivityWorkflow)
 worker.register_workflow(AsyncHelloWorldWorkflow)

--- a/lib/cadence/activity/poller.rb
+++ b/lib/cadence/activity/poller.rb
@@ -6,13 +6,16 @@ require 'cadence/activity/task_processor'
 module Cadence
   class Activity
     class Poller
-      THREAD_POOL_SIZE = 20
+      DEFAULT_OPTIONS = {
+        thread_pool_size: 20
+      }.freeze
 
-      def initialize(domain, task_list, activity_lookup, middleware = [])
+      def initialize(domain, task_list, activity_lookup, middleware = [], options = {})
         @domain = domain
         @task_list = task_list
         @activity_lookup = activity_lookup
         @middleware = middleware
+        @options = DEFAULT_OPTIONS.merge(options)
         @shutting_down = false
       end
 
@@ -33,10 +36,10 @@ module Cadence
 
       private
 
-      attr_reader :domain, :task_list, :activity_lookup, :middleware, :thread
+      attr_reader :domain, :task_list, :activity_lookup, :middleware, :options, :thread
 
       def client
-        @client ||= Cadence::Client.generate
+        @client ||= Cadence::Client.generate(options)
       end
 
       def shutting_down?
@@ -73,7 +76,7 @@ module Cadence
       end
 
       def thread_pool
-        @thread_pool ||= ThreadPool.new(THREAD_POOL_SIZE)
+        @thread_pool ||= ThreadPool.new(options[:thread_pool_size])
       end
     end
   end

--- a/lib/cadence/client.rb
+++ b/lib/cadence/client.rb
@@ -6,7 +6,7 @@ module Cadence
       thrift: Cadence::Client::ThriftClient
     }.freeze
 
-    def self.generate
+    def self.generate(options = {})
       client_class = CLIENT_TYPES_MAP[Cadence.configuration.client_type]
       host = Cadence.configuration.host
       port = Cadence.configuration.port
@@ -15,7 +15,7 @@ module Cadence
       thread_id = Thread.current.object_id
       identity = "#{thread_id}@#{hostname}"
 
-      client_class.new(host, port, identity)
+      client_class.new(host, port, identity, options)
     end
   end
 end

--- a/lib/cadence/client/thrift_client.rb
+++ b/lib/cadence/client/thrift_client.rb
@@ -13,9 +13,14 @@ module Cadence
         reject: CadenceThrift::WorkflowIdReusePolicy::RejectDuplicate
       }.freeze
 
-      def initialize(host, port, identity)
+      DEFAULT_OPTIONS = {
+        polling_ttl: 60 # 1 minute
+      }.freeze
+
+      def initialize(host, port, identity, options = {})
         @url = "http://#{host}:#{port}"
         @identity = identity
+        @options = DEFAULT_OPTIONS.merge(options)
         @mutex = Mutex.new
       end
 
@@ -325,7 +330,7 @@ module Cadence
 
       private
 
-      attr_reader :url, :identity, :mutex
+      attr_reader :url, :identity, :options, :mutex
 
       def transport
         @transport ||= Thrift::HTTPClientTransport.new(url).tap do |http|
@@ -333,7 +338,7 @@ module Cadence
             'Rpc-Caller' => 'ruby-client',
             'Rpc-Encoding' => 'thrift',
             'Rpc-Service' => 'cadence-proxy',
-            'Context-TTL-MS' => '25000'
+            'Context-TTL-MS' => (options[:polling_ttl] * 1_000).to_s
           )
         end
       end

--- a/lib/cadence/worker.rb
+++ b/lib/cadence/worker.rb
@@ -7,7 +7,8 @@ require 'cadence/middleware/entry'
 
 module Cadence
   class Worker
-    def initialize
+    def initialize(options = {})
+      @options = options
       @workflows = Hash.new { |hash, key| hash[key] = ExecutableLookup.new }
       @activities = Hash.new { |hash, key| hash[key] = ExecutableLookup.new }
       @pollers = []
@@ -66,18 +67,19 @@ module Cadence
 
     private
 
-    attr_reader :activities, :workflows, :pollers, :decision_middleware, :activity_middleware
+    attr_reader :options, :activities, :workflows, :pollers,
+                :decision_middleware, :activity_middleware
 
     def shutting_down?
       @shutting_down
     end
 
     def workflow_poller_for(domain, task_list, lookup)
-      Workflow::Poller.new(domain, task_list, lookup.freeze, decision_middleware)
+      Workflow::Poller.new(domain, task_list, lookup.freeze, decision_middleware, options)
     end
 
     def activity_poller_for(domain, task_list, lookup)
-      Activity::Poller.new(domain, task_list, lookup.freeze, activity_middleware)
+      Activity::Poller.new(domain, task_list, lookup.freeze, activity_middleware, options)
     end
 
     def trap_signals

--- a/lib/cadence/workflow/poller.rb
+++ b/lib/cadence/workflow/poller.rb
@@ -5,11 +5,12 @@ require 'cadence/workflow/decision_task_processor'
 module Cadence
   class Workflow
     class Poller
-      def initialize(domain, task_list, workflow_lookup, middleware = [])
+      def initialize(domain, task_list, workflow_lookup, middleware = [], options = {})
         @domain = domain
         @task_list = task_list
         @workflow_lookup = workflow_lookup
         @middleware = middleware
+        @options = options
         @shutting_down = false
       end
 
@@ -29,10 +30,10 @@ module Cadence
 
       private
 
-      attr_reader :domain, :task_list, :client, :workflow_lookup, :middleware
+      attr_reader :domain, :task_list, :client, :workflow_lookup, :middleware, :options
 
       def client
-        @client ||= Cadence::Client.generate
+        @client ||= Cadence::Client.generate(options)
       end
 
       def middleware_chain

--- a/spec/unit/lib/cadence/activity/poller_spec.rb
+++ b/spec/unit/lib/cadence/activity/poller_spec.rb
@@ -18,12 +18,12 @@ describe Cadence::Activity::Poller do
     allow(Cadence::Client).to receive(:generate).and_return(client)
     allow(Cadence::ThreadPool).to receive(:new).and_return(thread_pool)
     allow(Cadence::Middleware::Chain).to receive(:new).and_return(middleware_chain)
+    allow(client).to receive(:poll_for_activity_task).and_return(nil)
   end
 
   describe '#start' do
     it 'polls for activity tasks' do
       allow(subject).to receive(:shutting_down?).and_return(false, false, true)
-      allow(client).to receive(:poll_for_activity_task).and_return(nil)
 
       subject.start
 
@@ -34,6 +34,33 @@ describe Cadence::Activity::Poller do
         .to have_received(:poll_for_activity_task)
         .with(domain: domain, task_list: task_list)
         .twice
+    end
+
+    context 'with options passed' do
+      subject { described_class.new(domain, task_list, lookup, middleware, options) }
+      let(:options) { { polling_ttl: 42, thread_pool_size: 42 } }
+
+      before do
+        allow(subject).to receive(:shutting_down?).and_return(false, true)
+      end
+
+      it 'passes options to the client' do
+        subject.start
+
+        # stop poller before inspecting
+        subject.stop; subject.wait
+
+        expect(Cadence::Client).to have_received(:generate).with(options)
+      end
+
+      it 'creates thread pool of a specified size' do
+        subject.start
+
+        # stop poller before inspecting
+        subject.stop; subject.wait
+
+        expect(Cadence::ThreadPool).to have_received(:new).with(42)
+      end
     end
 
     context 'when an activity task is received' do


### PR DESCRIPTION
This will allow some extra flexibility when configuring the worker. Namely adding 2 options:

- `polling_ttl` — How long a poller should keep the connection option waiting for a task, specified in seconds
- `thread_pool_size` — How many thread a worker should use when processing activity tasks. Basically controls concurrency