### PR TITLE
Fix specs, fix cadence testing timeout issue, bump version to 0.0.1-pre43

### DIFF
--- a/lib/cadence/testing/local_workflow_context.rb
+++ b/lib/cadence/testing/local_workflow_context.rb
@@ -48,7 +48,12 @@ module Cadence
           workflow_run_id: run_id,
           workflow_id: workflow_id,
           workflow_name: nil, # not yet used, but will be in the future
-          headers: execution_options.headers
+          headers: execution_options.headers,
+          timeouts: {
+            start_to_close: 30,
+            schedule_to_close: 60,
+            heartbeat: 5
+          }
         )
         context = LocalActivityContext.new(metadata)
 
@@ -94,7 +99,12 @@ module Cadence
           workflow_run_id: run_id,
           workflow_id: workflow_id,
           workflow_name: nil, # not yet used, but will be in the future
-          headers: execution_options.headers
+          headers: execution_options.headers,
+          timeouts: {
+            schedule_to_close: 60,
+            start_to_close: 30,
+            heartbeat: 5
+          }
         )
         context = LocalActivityContext.new(metadata)
 

--- a/lib/cadence/version.rb
+++ b/lib/cadence/version.rb
@@ -1,3 +1,3 @@
 module Cadence
-  VERSION = '0.0.1-pre42'.freeze
+  VERSION = '0.0.1-pre43'.freeze
 end

--- a/spec/unit/lib/cadence/utils_spec.rb
+++ b/spec/unit/lib/cadence/utils_spec.rb
@@ -1,11 +1,11 @@
 require 'cadence/utils'
 
 describe Cadence::Utils do
-  let(:time) { Time.new(2020, 4, 28, 15, 23, 16) }
+  let(:timestamp) { 1588083796538941000 }
+  let(:time) { Time.at(timestamp / described_class::NANO) }
 
   describe '.time_from_nanos' do
     subject { described_class.time_from_nanos(timestamp) }
-    let(:timestamp) { 1588083796538941000 }
 
     it 'returns time' do
       expect(subject.to_i).to eq(time.to_i)

--- a/spec/unit/lib/cadence/workflow/context_spec.rb
+++ b/spec/unit/lib/cadence/workflow/context_spec.rb
@@ -6,7 +6,7 @@ describe Cadence::Workflow::Context do
     let(:state_manager) { instance_double('Cadence::Workflow::StateManager') }
     let(:dispatcher) { Cadence::Workflow::Dispatcher.new }
     let(:metadata_hash) do 
-        {name: 'TestWorkflow', run_id: SecureRandom.uuid, attempt: 0}
+        {name: 'TestWorkflow', run_id: SecureRandom.uuid, attempt: 0, timeouts: { execution: 15, task: 10 } }
     end
     let(:metadata) { Cadence::Metadata::Workflow.new(metadata_hash) }
     let(:context) { described_class.new(state_manager, dispatcher, metadata) }

--- a/spec/unit/lib/cadence_spec.rb
+++ b/spec/unit/lib/cadence_spec.rb
@@ -75,7 +75,7 @@ describe Cadence do
         it 'starts a cron workflow' do
           described_class.schedule_workflow(
             TestStartWorkflow,
-            '* * * * *'
+            '* * * * *',
             42,
             options: {
               name: 'test-workflow',


### PR DESCRIPTION
Some specs were broken so I cleaned those up.

The Cadence::Testing wasn't passing timeouts in to the Activity metadata causing tests to fail. Passed in some dummy values to allow it to work.

bumped version