### PR TITLE
Improve worker's reliability

### DIFF
--- a/lib/cadence/activity/poller.rb
+++ b/lib/cadence/activity/poller.rb
@@ -23,11 +23,12 @@ module Cadence
 
       def stop
         @shutting_down = true
-        Thread.new { Cadence.logger.info('Shutting down activity poller') }.join
+        Cadence.logger.info('Shutting down activity poller')
       end
 
       def wait
         thread.join
+        thread_pool.shutdown
       end
 
       private

--- a/lib/cadence/activity/task_processor.rb
+++ b/lib/cadence/activity/task_processor.rb
@@ -37,6 +37,10 @@ module Cadence
         respond_completed(result) unless context.async?
       rescue StandardError, ScriptError => error
         respond_failed(error.class.name, error.message)
+      rescue Exception => error
+        Cadence.logger.fatal("Activity #{activity_name} unexpectedly failed with: #{error.inspect}")
+        Cadence.logger.debug(error.backtrace.join("\n"))
+        raise
       ensure
         time_diff_ms = ((Time.now - start_time) * 1000).round
         Cadence.metrics.timing('activity_task.latency', time_diff_ms, activity: activity_name)

--- a/lib/cadence/thread_pool.rb
+++ b/lib/cadence/thread_pool.rb
@@ -50,14 +50,19 @@ module Cadence
     def poll
       catch(EXIT_SYMBOL) do
         loop do
-          job = @queue.pop
-          job.call
+          run(@queue.pop)
           @mutex.synchronize do
             @available_threads += 1
             @availability.signal
           end
         end
       end
+    end
+
+    def run(job)
+      job.call if job
+    rescue Exception
+      # Make sure we don't loose a thread
     end
   end
 end

--- a/lib/cadence/version.rb
+++ b/lib/cadence/version.rb
@@ -1,3 +1,3 @@
 module Cadence
-  VERSION = '0.0.1-pre43'.freeze
+  VERSION = '0.0.1-pre44'.freeze
 end

--- a/lib/cadence/worker.rb
+++ b/lib/cadence/worker.rb
@@ -51,16 +51,17 @@ module Cadence
 
       pollers.each(&:start)
 
-      # wait until instructed to shut down
-      while !shutting_down? do
-        sleep 1
-      end
+      # keep the main worker thread alive
+      sleep(1) while !shutting_down?
     end
 
     def stop
       @shutting_down = true
-      pollers.each(&:stop)
-      pollers.each(&:wait)
+
+      Thread.new do
+        pollers.each(&:stop)
+        pollers.each(&:wait)
+      end.join
     end
 
     private

--- a/lib/cadence/workflow/poller.rb
+++ b/lib/cadence/workflow/poller.rb
@@ -20,7 +20,7 @@ module Cadence
 
       def stop
         @shutting_down = true
-        Thread.new { Cadence.logger.info('Shutting down a workflow poller') }.join
+        Cadence.logger.info('Shutting down a workflow poller')
       end
 
       def wait

--- a/spec/unit/lib/cadence/activity/poller_spec.rb
+++ b/spec/unit/lib/cadence/activity/poller_spec.rb
@@ -6,7 +6,9 @@ describe Cadence::Activity::Poller do
   let(:domain) { 'test-domain' }
   let(:task_list) { 'test-task-list' }
   let(:lookup) { instance_double('Cadence::ExecutableLookup') }
-  let(:thread_pool) { instance_double(Cadence::ThreadPool, wait_for_available_threads: nil) }
+  let(:thread_pool) do
+    instance_double(Cadence::ThreadPool, wait_for_available_threads: nil, shutdown: nil)
+  end
   let(:middleware_chain) { instance_double(Cadence::Middleware::Chain) }
   let(:middleware) { [] }
 
@@ -108,6 +110,19 @@ describe Cadence::Activity::Poller do
           .to have_received(:error)
           .with('Unable to poll for an activity task: #<StandardError: StandardError>')
       end
+    end
+  end
+
+  describe '#wait' do
+    before do
+      subject.start
+      subject.stop
+    end
+
+    it 'shuts down the thread poll' do
+      subject.wait
+
+      expect(thread_pool).to have_received(:shutdown)
     end
   end
 end


### PR DESCRIPTION
A couple of improvements:

1. Make sure threads survive exceptions raised in Activities
2. Log any unhandled exceptions for debugging purposes
3. Make sure to stop all the thread pool threads when shutting down the worker