### PR TITLE
[Fix] Add requestId to reset_workflow_execution call

### DIFF
--- a/lib/cadence/client/thrift_client.rb
+++ b/lib/cadence/client/thrift_client.rb
@@ -250,7 +250,8 @@ module Cadence
             runId: run_id
           ),
           reason: reason,
-          decisionFinishEventId: decision_task_event_id
+          decisionFinishEventId: decision_task_event_id,
+          requestId: SecureRandom.uuid
         )
         send_request('ResetWorkflowExecution', request)
       end

--- a/lib/cadence/version.rb
+++ b/lib/cadence/version.rb
@@ -1,3 +1,3 @@
 module Cadence
-  VERSION = '0.0.1-pre45'.freeze
+  VERSION = '0.0.1-pre46'.freeze
 end

--- a/spec/unit/lib/cadence_spec.rb
+++ b/spec/unit/lib/cadence_spec.rb
@@ -275,6 +275,45 @@ describe Cadence do
       end
     end
 
+    describe '.reset_workflow' do
+      let(:cadence_response) { CadenceThrift::StartWorkflowExecutionResponse.new(runId: 'xxx') }
+
+      before { allow(client).to receive(:reset_workflow_execution).and_return(cadence_response) }
+
+      context 'when decision_task_id is provided' do
+        let(:decision_task_id) { 42 }
+
+        it 'calls client reset_workflow_execution' do
+          described_class.reset_workflow(
+            'default-test-domain',
+            '123',
+            '1234',
+            decision_task_id: decision_task_id,
+            reason: 'Test reset'
+          )
+
+          expect(client).to have_received(:reset_workflow_execution).with(
+            domain: 'default-test-domain',
+            workflow_id: '123',
+            run_id: '1234',
+            reason: 'Test reset',
+            decision_task_event_id: decision_task_id
+          )
+        end
+
+        it 'returns the new run_id' do
+          result = described_class.reset_workflow(
+            'default-test-domain',
+            '123',
+            '1234',
+            decision_task_id: decision_task_id
+          )
+
+          expect(result).to eq('xxx')
+        end
+      end
+    end
+
     context 'activity operations' do
       let(:domain) { 'test-domain' }
       let(:activity_id) { rand(100).to_s }


### PR DESCRIPTION
Without a provided `requestId` a workflow be only be reset once making all subsequent calls idempotent. This is not the expected behaviour for most part since it is useful to be able to reset a workflow multiple times.