### PR TITLE
Add support for paginated workflow history

### DIFF
--- a/lib/cadence/client/thrift_client.rb
+++ b/lib/cadence/client/thrift_client.rb
@@ -97,13 +97,14 @@ module Cadence
         send_request('StartWorkflowExecution', request)
       end
 
-      def get_workflow_execution_history(domain:, workflow_id:, run_id:)
+      def get_workflow_execution_history(domain:, workflow_id:, run_id:, next_page_token: nil)
         request = CadenceThrift::GetWorkflowExecutionHistoryRequest.new(
           domain: domain,
           execution: CadenceThrift::WorkflowExecution.new(
             workflowId: workflow_id,
             runId: run_id
-          )
+          ),
+          nextPageToken: next_page_token
         )
 
         send_request('GetWorkflowExecutionHistory', request)

--- a/lib/cadence/version.rb
+++ b/lib/cadence/version.rb
@@ -1,3 +1,3 @@
 module Cadence
-  VERSION = '0.0.1-pre47'.freeze
+  VERSION = '0.0.1-pre48'.freeze
 end

--- a/lib/cadence/workflow/decision_task_processor.rb
+++ b/lib/cadence/workflow/decision_task_processor.rb
@@ -27,7 +27,7 @@ module Cadence
           return
         end
 
-        history = Workflow::History.new(task.history.events)
+        history = fetch_full_history
         # TODO: For sticky workflows we need to cache the Executor instance
         executor = Workflow::Executor.new(workflow_class, history)
         metadata = Metadata.generate(Metadata::DECISION_TYPE, task, domain)
@@ -56,6 +56,25 @@ module Cadence
 
       def serialize_decisions(decisions)
         decisions.map { |(_, decision)| Workflow::Serializer.serialize(decision) }
+      end
+
+      def fetch_full_history
+        events = task.history.events.to_a
+        next_page_token = task.nextPageToken
+
+        while next_page_token do
+          response = client.get_workflow_execution_history(
+            domain: domain,
+            workflow_id: task.workflowExecution.workflowId,
+            run_id: task.workflowExecution.runId,
+            next_page_token: next_page_token
+          )
+
+          events += response.history.events.to_a
+          next_page_token = response.nextPageToken
+        end
+
+        Workflow::History.new(events)
       end
 
       def complete_task(decisions)

--- a/spec/fabricators/thrift/decision_task_fabricator.rb
+++ b/spec/fabricators/thrift/decision_task_fabricator.rb
@@ -11,4 +11,6 @@ Fabricator(:decision_task_thrift, from: CadenceThrift::PollForDecisionTaskRespon
   workflowExecution { Fabricate(:workflow_execution_thrift) }
   scheduledTimestamp { Cadence::Utils.time_to_nanos(Time.now) }
   startedTimestamp { Cadence::Utils.time_to_nanos(Time.now) }
+  history { Fabricate(:history_thrift) }
+  nextPageToken nil
 end

--- a/spec/fabricators/thrift/history_event_fabricator.rb
+++ b/spec/fabricators/thrift/history_event_fabricator.rb
@@ -1,0 +1,70 @@
+require 'gen/thrift/cadence_types'
+require 'cadence/utils'
+require 'securerandom'
+
+Fabricator(:history_event_thrift, from: CadenceThrift::HistoryEvent) do
+  eventId { 1 }
+  timestamp { Cadence::Utils.time_to_nanos(Time.now) }
+end
+
+Fabricator(:workflow_execution_started_event_thrift, from: :history_event_thrift) do
+  eventType { CadenceThrift::EventType::WorkflowExecutionStarted }
+  workflowExecutionStartedEventAttributes do
+    CadenceThrift::WorkflowExecutionStartedEventAttributes.new(
+      workflowType: Fabricate(:workflow_type_thrift),
+      taskList: Fabricate(:task_list_thrift),
+      input: nil,
+      executionStartToCloseTimeoutSeconds: 60,
+      taskStartToCloseTimeoutSeconds: 15,
+      originalExecutionRunId: SecureRandom.uuid,
+      identity: 'test-worker@test-host',
+      firstExecutionRunId: SecureRandom.uuid,
+      retryPolicy: nil,
+      attempt: 0,
+      header: Fabricate(:header_thrift)
+    )
+  end
+end
+
+Fabricator(:workflow_execution_completed_event_thrift, from: :history_event_thrift) do
+  eventType { CadenceThrift::EventType::WorkflowExecutionCompleted }
+  workflowExecutionCompletedEventAttributes do |attrs|
+    CadenceThrift::WorkflowExecutionCompletedEventAttributes.new(
+      result: nil,
+      decisionTaskCompletedEventId: attrs[:eventId] - 1
+    )
+  end
+end
+
+Fabricator(:decision_task_scheduled_event_thrift, from: :history_event_thrift) do
+  eventType { CadenceThrift::EventType::DecisionTaskScheduled }
+  decisionTaskScheduledEventAttributes do |attrs|
+    CadenceThrift::DecisionTaskScheduledEventAttributes.new(
+      taskList: Fabricate(:task_list_thrift),
+      startToCloseTimeoutSeconds: 15,
+      attempt: 0
+    )
+  end
+end
+
+Fabricator(:decision_task_started_event_thrift, from: :history_event_thrift) do
+  eventType { CadenceThrift::EventType::DecisionTaskStarted }
+  decisionTaskStartedEventAttributes do |attrs|
+    CadenceThrift::DecisionTaskStartedEventAttributes.new(
+      scheduledEventId: attrs[:eventId] - 1,
+      identity: 'test-worker@test-host',
+      requestId: SecureRandom.uuid
+    )
+  end
+end
+
+Fabricator(:decision_task_completed_event_thrift, from: :history_event_thrift) do
+  eventType { CadenceThrift::EventType::DecisionTaskCompleted }
+  decisionTaskCompletedEventAttributes do |attrs|
+    CadenceThrift::DecisionTaskCompletedEventAttributes.new(
+      scheduledEventId: attrs[:eventId] - 2,
+      startedEventId: attrs[:eventId] - 1,
+      identity: 'test-worker@test-host'
+    )
+  end
+end

--- a/spec/fabricators/thrift/history_fabricator.rb
+++ b/spec/fabricators/thrift/history_fabricator.rb
@@ -1,0 +1,13 @@
+require 'gen/thrift/cadence_types'
+
+Fabricator(:history_thrift, from: CadenceThrift::History) do
+  events do
+    [
+      Fabricate(:workflow_execution_started_event_thrift, eventId: 1),
+      Fabricate(:decision_task_scheduled_event_thrift, eventId: 2),
+      Fabricate(:decision_task_started_event_thrift, eventId: 3),
+      Fabricate(:decision_task_completed_event_thrift, eventId: 4),
+      Fabricate(:workflow_execution_completed_event_thrift, eventId: 5)
+    ]
+  end
+end

--- a/spec/fabricators/thrift/task_list_fabricator.rb
+++ b/spec/fabricators/thrift/task_list_fabricator.rb
@@ -1,0 +1,5 @@
+require 'gen/thrift/cadence_types'
+
+Fabricator(:task_list_thrift, from: CadenceThrift::TaskList) do
+  name 'test-task-list'
+end

--- a/spec/fabricators/thrift/workflow_execution_history_fabricator.rb
+++ b/spec/fabricators/thrift/workflow_execution_history_fabricator.rb
@@ -1,0 +1,9 @@
+require 'gen/thrift/cadence_types'
+
+Fabricator(
+  :worklfow_execution_history_thrift,
+  from: CadenceThrift::GetWorkflowExecutionHistoryResponse
+) do
+  history { Fabricate(:history_thrift) }
+  nextPageToken nil
+end

--- a/spec/unit/lib/cadence/workflow/decision_task_processor_spec.rb
+++ b/spec/unit/lib/cadence/workflow/decision_task_processor_spec.rb
@@ -1,0 +1,170 @@
+require 'cadence/workflow/decision_task_processor'
+require 'cadence/workflow'
+require 'cadence/executable_lookup'
+require 'cadence/client/thrift_client'
+require 'cadence/middleware/chain'
+
+describe Cadence::Workflow::DecisionTaskProcessor do
+  class TestWorkflow < Cadence::Workflow; end
+
+  subject { described_class.new(task, domain, lookup, client, middleware_chain) }
+
+  let(:task) { Fabricate(:decision_task_thrift) }
+  let(:domain) { 'test-domain' }
+  let(:lookup) { Cadence::ExecutableLookup.new }
+  let(:client) do
+    instance_double(
+      Cadence::Client::ThriftClient,
+      respond_decision_task_completed: nil,
+      respond_decision_task_failed: nil
+    )
+  end
+  let(:middleware_chain) { Cadence::Middleware::Chain.new }
+  let(:executor) { instance_double(Cadence::Workflow::Executor, run: []) }
+
+  before do
+    allow(Cadence.metrics).to receive(:timing)
+    allow(Cadence.logger).to receive(:info)
+    allow(Cadence.logger).to receive(:error)
+    allow(Cadence.logger).to receive(:debug)
+  end
+
+  context 'when workflow is registered' do
+    before do
+      lookup.add('TestWorkflow', TestWorkflow)
+
+      allow(Cadence::Workflow::Executor)
+        .to receive(:new)
+        .with(TestWorkflow, an_instance_of(Cadence::Workflow::History))
+        .and_return(executor)
+    end
+
+    it 'runs the workflow executor' do
+      subject.process
+
+      expect(Cadence::Workflow::Executor).to have_received(:new) do |workflow_class, history|
+        expect(workflow_class).to eq(TestWorkflow)
+        expect(history.events.length).to eq(5)
+      end
+
+      expect(executor).to have_received(:run)
+    end
+
+    it 'invokes the middleware chain' do
+      allow(middleware_chain).to receive(:invoke).and_call_original
+
+      subject.process
+
+      expect(middleware_chain).to have_received(:invoke)
+    end
+
+    it 'completes the decision task' do
+      subject.process
+
+      expect(client)
+        .to have_received(:respond_decision_task_completed)
+        .with(task_token: task.taskToken, decisions: [])
+    end
+
+    it 'emits latency metrics' do
+      subject.process
+
+      expect(Cadence.metrics)
+        .to have_received(:timing)
+        .with('decision_task.queue_time', an_instance_of(Integer), workflow: 'TestWorkflow')
+
+      expect(Cadence.metrics)
+        .to have_received(:timing)
+        .with('decision_task.latency', an_instance_of(Integer), workflow: 'TestWorkflow')
+    end
+
+    context 'when history is paginated' do
+      let(:task) { Fabricate(:decision_task_thrift, nextPageToken: 'token-1') }
+      let(:history_1) { Fabricate(:worklfow_execution_history_thrift, nextPageToken: 'token-2') }
+      let(:history_2) { Fabricate(:worklfow_execution_history_thrift, nextPageToken: nil) }
+
+      before do
+        allow(client)
+          .to receive(:get_workflow_execution_history)
+          .and_return(history_1, history_2)
+      end
+
+      it 'fetches missing history pages' do
+        subject.process
+
+        expect(client)
+          .to have_received(:get_workflow_execution_history)
+          .with(
+            domain: domain,
+            workflow_id: task.workflowExecution.workflowId,
+            run_id: task.workflowExecution.runId,
+            next_page_token: task.nextPageToken
+          )
+
+        expect(client)
+          .to have_received(:get_workflow_execution_history)
+          .with(
+            domain: domain,
+            workflow_id: task.workflowExecution.workflowId,
+            run_id: task.workflowExecution.runId,
+            next_page_token: history_1.nextPageToken
+          )
+      end
+
+      it 'passes full history to the workflow executor' do
+        subject.process
+
+        expect(Cadence::Workflow::Executor).to have_received(:new) do |workflow_class, history|
+          expect(workflow_class).to eq(TestWorkflow)
+          expect(history.events.length).to eq(15)
+        end
+      end
+    end
+
+    context 'when unable to complete a workflow' do
+      before do
+        allow(client)
+          .to receive(:respond_decision_task_completed)
+          .and_raise(StandardError, 'Host unreachable')
+      end
+
+      it 'does not raise' do
+        expect { subject.process }.not_to raise_error
+      end
+
+      it 'logs the error' do
+        subject.process
+
+        expect(Cadence.logger)
+          .to have_received(:error)
+          .with("Decison task for TestWorkflow failed with: #<StandardError: Host unreachable>")
+      end
+    end
+  end
+
+  context 'when workflow class is not registered' do
+    it 'fails the decision task' do
+      subject.process
+
+      expect(client)
+        .to have_received(:respond_decision_task_failed)
+        .with(
+          task_token: task.taskToken,
+          cause: CadenceThrift::DecisionTaskFailedCause::UNHANDLED_DECISION,
+          details: { message: 'Workflow does not exist' }
+        )
+    end
+
+    it 'emits latency metrics' do
+      subject.process
+
+      expect(Cadence.metrics)
+        .to have_received(:timing)
+        .with('decision_task.queue_time', an_instance_of(Integer), workflow: 'TestWorkflow')
+
+      expect(Cadence.metrics)
+        .to have_received(:timing)
+        .with('decision_task.latency', an_instance_of(Integer), workflow: 'TestWorkflow')
+    end
+  end
+end


### PR DESCRIPTION
Cadence paginates history when it becomes too big, this PR enables the gem to prefetch all of it before processing a decision task.

Also added a full spec for DecisionTaskProcessor along with this a spec for this change