### PR TITLE
[Feature] Report time between poller loops

### DIFF
--- a/lib/cadence/activity/poller.rb
+++ b/lib/cadence/activity/poller.rb
@@ -48,7 +48,7 @@ module Cadence
 
       def poll_loop
         last_poll_time = Time.now
-        metrics_tags = { domain: domain, task_list: task_list }
+        metrics_tags = { domain: domain, task_list: task_list }.freeze
 
         loop do
           thread_pool.wait_for_available_threads

--- a/lib/cadence/workflow/poller.rb
+++ b/lib/cadence/workflow/poller.rb
@@ -46,7 +46,7 @@ module Cadence
 
       def poll_loop
         last_poll_time = Time.now
-        metrics_tags = { domain: domain, task_list: task_list }
+        metrics_tags = { domain: domain, task_list: task_list }.freeze
 
         while !shutting_down? do
           time_diff_ms = ((Time.now - last_poll_time) * 1000).round

--- a/lib/cadence/workflow/poller.rb
+++ b/lib/cadence/workflow/poller.rb
@@ -45,10 +45,16 @@ module Cadence
       end
 
       def poll_loop
+        last_poll_time = Time.now
+        metrics_tags = { domain: domain, task_list: task_list }
+
         while !shutting_down? do
+          time_diff_ms = ((Time.now - last_poll_time) * 1000).round
+          Cadence.metrics.timing('workflow_poller.time_since_last_poll', time_diff_ms, metrics_tags)
           Cadence.logger.debug("Polling for decision tasks (#{domain} / #{task_list})")
 
           task = poll_for_task
+          last_poll_time = Time.now
           process(task) if task&.workflowType
         end
       end

--- a/spec/unit/lib/cadence/workflow/poller_spec.rb
+++ b/spec/unit/lib/cadence/workflow/poller_spec.rb
@@ -1,0 +1,124 @@
+require 'cadence/workflow/poller'
+require 'cadence/middleware/entry'
+
+describe Cadence::Workflow::Poller do
+  let(:client) { instance_double('Cadence::Client::ThriftClient') }
+  let(:domain) { 'test-domain' }
+  let(:task_list) { 'test-task-list' }
+  let(:lookup) { instance_double('Cadence::ExecutableLookup') }
+  let(:middleware_chain) { instance_double(Cadence::Middleware::Chain) }
+  let(:middleware) { [] }
+
+  subject { described_class.new(domain, task_list, lookup, middleware) }
+
+  before do
+    allow(Cadence::Client).to receive(:generate).and_return(client)
+    allow(Cadence::Middleware::Chain).to receive(:new).and_return(middleware_chain)
+    allow(Cadence.metrics).to receive(:timing)
+  end
+
+  describe '#start' do
+    it 'polls for decision tasks' do
+      allow(subject).to receive(:shutting_down?).and_return(false, false, true)
+      allow(client).to receive(:poll_for_decision_task).and_return(nil)
+
+      subject.start
+
+      # stop poller before inspecting
+      subject.stop; subject.wait
+
+      expect(client)
+        .to have_received(:poll_for_decision_task)
+        .with(domain: domain, task_list: task_list)
+        .twice
+    end
+
+    it 'polls for decision tasks' do
+      allow(subject).to receive(:shutting_down?).and_return(false, false, true)
+      allow(client).to receive(:poll_for_decision_task).and_return(nil)
+
+      subject.start
+
+      # stop poller before inspecting
+      subject.stop; subject.wait
+
+      expect(Cadence.metrics)
+        .to have_received(:timing)
+        .with(
+          'workflow_poller.time_since_last_poll',
+          an_instance_of(Fixnum),
+          domain: domain,
+          task_list: task_list
+        )
+        .twice
+    end
+
+    context 'when an decision task is received' do
+      let(:task_processor) do
+        instance_double(Cadence::Workflow::DecisionTaskProcessor, process: nil)
+      end
+      let(:task) { Fabricate(:decision_task_thrift) }
+
+      before do
+        allow(subject).to receive(:shutting_down?).and_return(false, true)
+        allow(client).to receive(:poll_for_decision_task).and_return(task)
+        allow(Cadence::Workflow::DecisionTaskProcessor).to receive(:new).and_return(task_processor)
+      end
+
+      it 'uses DecisionTaskProcessor to process tasks' do
+        subject.start
+
+        # stop poller before inspecting
+        subject.stop; subject.wait
+
+        expect(Cadence::Workflow::DecisionTaskProcessor)
+          .to have_received(:new)
+          .with(task, domain, lookup, client, middleware_chain)
+        expect(task_processor).to have_received(:process)
+      end
+
+      context 'with middleware configured' do
+        class TestPollerMiddleware
+          def initialize(_); end
+          def call(_); end
+        end
+
+        let(:middleware) { [entry_1, entry_2] }
+        let(:entry_1) { Cadence::Middleware::Entry.new(TestPollerMiddleware, '1') }
+        let(:entry_2) { Cadence::Middleware::Entry.new(TestPollerMiddleware, '2') }
+
+        it 'initializes middleware chain and passes it down to DecisionTaskProcessor' do
+          subject.start
+
+          # stop poller before inspecting
+          subject.stop; subject.wait
+
+          expect(Cadence::Middleware::Chain).to have_received(:new).with(middleware)
+          expect(Cadence::Workflow::DecisionTaskProcessor)
+            .to have_received(:new)
+            .with(task, domain, lookup, client, middleware_chain)
+        end
+      end
+    end
+
+    context 'when client is unable to poll' do
+      before do
+        allow(subject).to receive(:shutting_down?).and_return(false, true)
+        allow(client).to receive(:poll_for_decision_task).and_raise(StandardError)
+      end
+
+      it 'logs' do
+        allow(Cadence.logger).to receive(:error)
+
+        subject.start
+
+        # stop poller before inspecting
+        subject.stop; subject.wait
+
+        expect(Cadence.logger)
+          .to have_received(:error)
+          .with('Unable to poll for a decision task: #<StandardError: StandardError>')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This new metric will help detect resource contention on Cadence workers. Increased time between polls indicates thread unavailability (in case of activity poller) and slow decision processing (for the workflow poller)