### PR TITLE
[Feature] Add thread pool support to the workflow poller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.1
+- Add thread pool support to workflow pollers
+
 ## 0.1.0
 - Add basic non-determinism check for workflow replay
 - Make worker thread count & poller TTL configurable

--- a/lib/cadence/version.rb
+++ b/lib/cadence/version.rb
@@ -1,3 +1,3 @@
 module Cadence
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.1.1'.freeze
 end

--- a/spec/unit/lib/cadence/activity/poller_spec.rb
+++ b/spec/unit/lib/cadence/activity/poller_spec.rb
@@ -39,7 +39,6 @@ describe Cadence::Activity::Poller do
 
     it 'polls for activity tasks' do
       allow(subject).to receive(:shutting_down?).and_return(false, false, true)
-      allow(client).to receive(:poll_for_activity_task).and_return(nil)
 
       subject.start
 


### PR DESCRIPTION
After heavy load-testing it looks like workflow workers spend most of their time communicating results back to Cadence. Previously it was assumed that they are CPU-bound so thread pooling would not bring any benefits. But since this is not necessarily the case, thread pooling will allow running less workflow workers to sustain the same decision task throughput.