### PR TITLE
[Refactor] Use local configuration instead of a global one

### DIFF
--- a/lib/cadence.rb
+++ b/lib/cadence.rb
@@ -15,7 +15,7 @@ module Cadence
       options = args.delete(:options) || {}
       input << args unless args.empty?
 
-      execution_options = ExecutionOptions.new(workflow, options, config.for_execution)
+      execution_options = ExecutionOptions.new(workflow, options, config.default_execution_options)
       workflow_id = options[:workflow_id] || SecureRandom.uuid
 
       response = connection.start_workflow_execution(
@@ -37,7 +37,7 @@ module Cadence
       options = args.delete(:options) || {}
       input << args unless args.empty?
 
-      execution_options = ExecutionOptions.new(workflow, options, config.for_execution)
+      execution_options = ExecutionOptions.new(workflow, options, config.default_execution_options)
       workflow_id = options[:workflow_id] || SecureRandom.uuid
 
       response = connection.start_workflow_execution(

--- a/lib/cadence.rb
+++ b/lib/cadence.rb
@@ -15,7 +15,7 @@ module Cadence
       options = args.delete(:options) || {}
       input << args unless args.empty?
 
-      execution_options = ExecutionOptions.new(workflow, options)
+      execution_options = ExecutionOptions.new(workflow, options, config.for_execution)
       workflow_id = options[:workflow_id] || SecureRandom.uuid
 
       response = connection.start_workflow_execution(
@@ -37,7 +37,7 @@ module Cadence
       options = args.delete(:options) || {}
       input << args unless args.empty?
 
-      execution_options = ExecutionOptions.new(workflow, options)
+      execution_options = ExecutionOptions.new(workflow, options, config.for_execution)
       workflow_id = options[:workflow_id] || SecureRandom.uuid
 
       response = connection.start_workflow_execution(
@@ -133,19 +133,20 @@ module Cadence
     end
 
     def configure(&block)
-      yield configuration
+      yield config
     end
 
     def configuration
-      @configuration ||= Configuration.new
+      warn '[DEPRECATION] This method is now deprecated without a substitution'
+      config
     end
 
     def logger
-      configuration.logger
+      config.logger
     end
 
     def metrics
-      @metrics ||= Metrics.new(configuration.metrics_adapter)
+      @metrics ||= Metrics.new(config.metrics_adapter)
     end
 
     def get_workflow_history(domain:, workflow_id:, run_id:)
@@ -159,8 +160,12 @@ module Cadence
 
     private
 
+    def config
+      @config ||= Configuration.new
+    end
+
     def connection
-      @connection ||= Cadence::Connection.generate
+      @connection ||= Cadence::Connection.generate(config.for_connection)
     end
 
     def get_last_completed_decision_task(domain, workflow_id, run_id)

--- a/lib/cadence/activity/context.rb
+++ b/lib/cadence/activity/context.rb
@@ -7,8 +7,8 @@ require 'cadence/activity/async_token'
 module Cadence
   class Activity
     class Context
-      def initialize(client, metadata)
-        @client = client
+      def initialize(connection, metadata)
+        @connection = connection
         @metadata = metadata
         @async = false
       end
@@ -32,7 +32,7 @@ module Cadence
 
       def heartbeat(details = nil)
         logger.debug('Activity heartbeat')
-        client.record_activity_task_heartbeat(task_token: task_token, details: details)
+        connection.record_activity_task_heartbeat(task_token: task_token, details: details)
       end
 
       def logger
@@ -54,7 +54,7 @@ module Cadence
 
       private
 
-      attr_reader :client, :metadata
+      attr_reader :connection, :metadata
 
       def task_token
         metadata.task_token

--- a/lib/cadence/activity/poller.rb
+++ b/lib/cadence/activity/poller.rb
@@ -1,4 +1,4 @@
-require 'cadence/client'
+require 'cadence/connection'
 require 'cadence/thread_pool'
 require 'cadence/middleware/chain'
 require 'cadence/activity/task_processor'
@@ -38,8 +38,8 @@ module Cadence
 
       attr_reader :domain, :task_list, :activity_lookup, :middleware, :options, :thread
 
-      def client
-        @client ||= Cadence::Client.generate(options)
+      def connection
+        @connection ||= Cadence::Connection.generate(options)
       end
 
       def shutting_down?
@@ -68,17 +68,17 @@ module Cadence
       end
 
       def poll_for_task
-        client.poll_for_activity_task(domain: domain, task_list: task_list)
+        connection.poll_for_activity_task(domain: domain, task_list: task_list)
       rescue StandardError => error
         Cadence.logger.error("Unable to poll for an activity task: #{error.inspect}")
         nil
       end
 
       def process(task)
-        client = Cadence::Client.generate
+        connection = Cadence::Connection.generate
         middleware_chain = Middleware::Chain.new(middleware)
 
-        TaskProcessor.new(task, domain, activity_lookup, client, middleware_chain).process
+        TaskProcessor.new(task, domain, activity_lookup, connection, middleware_chain).process
       end
 
       def thread_pool

--- a/lib/cadence/activity/poller.rb
+++ b/lib/cadence/activity/poller.rb
@@ -10,10 +10,11 @@ module Cadence
         thread_pool_size: 20
       }.freeze
 
-      def initialize(domain, task_list, activity_lookup, middleware = [], options = {})
+      def initialize(domain, task_list, activity_lookup, config, middleware = [], options = {})
         @domain = domain
         @task_list = task_list
         @activity_lookup = activity_lookup
+        @config = config
         @middleware = middleware
         @options = DEFAULT_OPTIONS.merge(options)
         @shutting_down = false
@@ -36,10 +37,10 @@ module Cadence
 
       private
 
-      attr_reader :domain, :task_list, :activity_lookup, :middleware, :options, :thread
+      attr_reader :domain, :task_list, :activity_lookup, :config, :middleware, :options, :thread
 
       def connection
-        @connection ||= Cadence::Connection.generate(options)
+        @connection ||= Cadence::Connection.generate(config.for_connection, options)
       end
 
       def shutting_down?
@@ -75,7 +76,7 @@ module Cadence
       end
 
       def process(task)
-        connection = Cadence::Connection.generate
+        connection = Cadence::Connection.generate(config.for_connection)
         middleware_chain = Middleware::Chain.new(middleware)
 
         TaskProcessor.new(task, domain, activity_lookup, connection, middleware_chain).process

--- a/lib/cadence/activity/poller.rb
+++ b/lib/cadence/activity/poller.rb
@@ -76,10 +76,9 @@ module Cadence
       end
 
       def process(task)
-        connection = Cadence::Connection.generate(config.for_connection)
         middleware_chain = Middleware::Chain.new(middleware)
 
-        TaskProcessor.new(task, domain, activity_lookup, connection, middleware_chain).process
+        TaskProcessor.new(task, domain, activity_lookup, middleware_chain, config).process
       end
 
       def thread_pool

--- a/lib/cadence/activity/task_processor.rb
+++ b/lib/cadence/activity/task_processor.rb
@@ -5,13 +5,13 @@ require 'cadence/json'
 module Cadence
   class Activity
     class TaskProcessor
-      def initialize(task, domain, activity_lookup, client, middleware_chain)
+      def initialize(task, domain, activity_lookup, connection, middleware_chain)
         @task = task
         @domain = domain
         @task_token = task.taskToken
         @activity_name = task.activityType.name
         @activity_class = activity_lookup.find(activity_name)
-        @client = client
+        @connection = connection
         @middleware_chain = middleware_chain
       end
 
@@ -27,7 +27,7 @@ module Cadence
         end
 
         metadata = Metadata.generate(Metadata::ACTIVITY_TYPE, task, domain)
-        context = Activity::Context.new(client, metadata)
+        context = Activity::Context.new(connection, metadata)
 
         result = middleware_chain.invoke(metadata) do
           activity_class.execute_in_context(context, JSON.deserialize(task.input))
@@ -49,7 +49,7 @@ module Cadence
 
       private
 
-      attr_reader :task, :domain, :task_token, :activity_name, :activity_class, :client, :middleware_chain
+      attr_reader :task, :domain, :task_token, :activity_name, :activity_class, :connection, :middleware_chain
 
       def queue_time_ms
         ((task.startedTimestamp - task.scheduledTimestampOfThisAttempt) / 1_000_000).round
@@ -57,14 +57,14 @@ module Cadence
 
       def respond_completed(result)
         Cadence.logger.info("Activity #{activity_name} completed")
-        client.respond_activity_task_completed(task_token: task_token, result: result)
+        connection.respond_activity_task_completed(task_token: task_token, result: result)
       rescue StandardError => error
         Cadence.logger.error("Unable to complete Activity #{activity_name}: #{error.inspect}")
       end
 
       def respond_failed(reason, details)
         Cadence.logger.error("Activity #{activity_name} failed with: #{reason}")
-        client.respond_activity_task_failed(task_token: task_token, reason: reason, details: details)
+        connection.respond_activity_task_failed(task_token: task_token, reason: reason, details: details)
       rescue StandardError => error
         Cadence.logger.error("Unable to fail Activity #{activity_name}: #{error.inspect}")
       end

--- a/lib/cadence/activity/task_processor.rb
+++ b/lib/cadence/activity/task_processor.rb
@@ -1,18 +1,19 @@
 require 'cadence/metadata'
 require 'cadence/activity/context'
 require 'cadence/json'
+require 'cadence/connection'
 
 module Cadence
   class Activity
     class TaskProcessor
-      def initialize(task, domain, activity_lookup, connection, middleware_chain)
+      def initialize(task, domain, activity_lookup, middleware_chain, config)
         @task = task
         @domain = domain
         @task_token = task.taskToken
         @activity_name = task.activityType.name
         @activity_class = activity_lookup.find(activity_name)
-        @connection = connection
         @middleware_chain = middleware_chain
+        @config = config
       end
 
       def process
@@ -49,7 +50,12 @@ module Cadence
 
       private
 
-      attr_reader :task, :domain, :task_token, :activity_name, :activity_class, :connection, :middleware_chain
+      attr_reader :task, :domain, :task_token, :activity_name, :activity_class,
+        :middleware_chain, :config
+
+      def connection
+        @connection ||= Cadence::Connection.generate(config.for_connection)
+      end
 
       def queue_time_ms
         ((task.startedTimestamp - task.scheduledTimestampOfThisAttempt) / 1_000_000).round

--- a/lib/cadence/configuration.rb
+++ b/lib/cadence/configuration.rb
@@ -3,6 +3,9 @@ require 'cadence/metrics_adapters/null'
 
 module Cadence
   class Configuration
+    Connection = Struct.new(:type, :host, :port, keyword_init: true)
+    Execution = Struct.new(:domain, :task_list, :timeouts, :headers, keyword_init: true)
+
     attr_reader :timeouts
     attr_accessor :connection_type, :host, :port, :logger, :metrics_adapter, :domain, :task_list, :headers
 
@@ -31,6 +34,23 @@ module Cadence
 
     def timeouts=(new_timeouts)
       @timeouts = DEFAULT_TIMEOUTS.merge(new_timeouts)
+    end
+
+    def for_connection
+      Connection.new(
+        type: connection_type,
+        host: host,
+        port: port
+      ).freeze
+    end
+
+    def for_execution
+      Execution.new(
+        domain: domain,
+        task_list: task_list,
+        timeouts: timeouts,
+        headers: headers
+      ).freeze
     end
   end
 end

--- a/lib/cadence/configuration.rb
+++ b/lib/cadence/configuration.rb
@@ -44,7 +44,7 @@ module Cadence
       ).freeze
     end
 
-    def for_execution
+    def default_execution_options
       Execution.new(
         domain: domain,
         task_list: task_list,

--- a/lib/cadence/configuration.rb
+++ b/lib/cadence/configuration.rb
@@ -4,7 +4,7 @@ require 'cadence/metrics_adapters/null'
 module Cadence
   class Configuration
     attr_reader :timeouts
-    attr_accessor :client_type, :host, :port, :logger, :metrics_adapter, :domain, :task_list, :headers
+    attr_accessor :connection_type, :host, :port, :logger, :metrics_adapter, :domain, :task_list, :headers
 
     DEFAULT_TIMEOUTS = {
       execution: 60,          # End-to-end workflow time
@@ -20,7 +20,7 @@ module Cadence
     DEFAULT_TASK_LIST = 'default-task-list'.freeze
 
     def initialize
-      @client_type = :thrift
+      @connection_type = :thrift
       @logger = Logger.new(STDOUT, progname: 'cadence_client')
       @metrics_adapter = MetricsAdapters::Null.new
       @timeouts = DEFAULT_TIMEOUTS

--- a/lib/cadence/connection.rb
+++ b/lib/cadence/connection.rb
@@ -6,10 +6,10 @@ module Cadence
       thrift: Cadence::Connection::Thrift
     }.freeze
 
-    def self.generate(options = {})
-      connection_class = CLIENT_TYPES_MAP[Cadence.configuration.connection_type]
-      host = Cadence.configuration.host
-      port = Cadence.configuration.port
+    def self.generate(configuration, options = {})
+      connection_class = CLIENT_TYPES_MAP[configuration.type]
+      host = configuration.host
+      port = configuration.port
 
       hostname = `hostname`
       thread_id = Thread.current.object_id

--- a/lib/cadence/connection.rb
+++ b/lib/cadence/connection.rb
@@ -1,13 +1,13 @@
-require 'cadence/client/thrift_client'
+require 'cadence/connection/thrift'
 
 module Cadence
-  module Client
+  module Connection
     CLIENT_TYPES_MAP = {
-      thrift: Cadence::Client::ThriftClient
+      thrift: Cadence::Connection::Thrift
     }.freeze
 
     def self.generate(options = {})
-      client_class = CLIENT_TYPES_MAP[Cadence.configuration.client_type]
+      connection_class = CLIENT_TYPES_MAP[Cadence.configuration.connection_type]
       host = Cadence.configuration.host
       port = Cadence.configuration.port
 
@@ -15,7 +15,7 @@ module Cadence
       thread_id = Thread.current.object_id
       identity = "#{thread_id}@#{hostname}"
 
-      client_class.new(host, port, identity, options)
+      connection_class.new(host, port, identity, options)
     end
   end
 end

--- a/lib/cadence/connection/errors.rb
+++ b/lib/cadence/connection/errors.rb
@@ -1,8 +1,8 @@
 module Cadence
-  module Client
+  module Connection
     class Error < StandardError; end
 
-    # incorrect arguments passed to the client
+    # incorrect arguments passed to the connection
     class ArgumentError < Error; end
   end
 end

--- a/lib/cadence/connection/thrift.rb
+++ b/lib/cadence/connection/thrift.rb
@@ -1,12 +1,12 @@
 require 'thrift'
 require 'securerandom'
 require 'cadence/json'
-require 'cadence/client/errors'
+require 'cadence/connection/errors'
 require 'gen/thrift/workflow_service'
 
 module Cadence
-  module Client
-    class ThriftClient
+  module Connection
+    class Thrift
       WORKFLOW_ID_REUSE_POLICY = {
         allow_failed: CadenceThrift::WorkflowIdReusePolicy::AllowDuplicateFailedOnly,
         allow: CadenceThrift::WorkflowIdReusePolicy::AllowDuplicate,
@@ -344,7 +344,7 @@ module Cadence
       attr_reader :url, :identity, :options, :mutex
 
       def transport
-        @transport ||= Thrift::HTTPClientTransport.new(url).tap do |http|
+        @transport ||= ::Thrift::HTTPClientTransport.new(url).tap do |http|
           http.add_headers(
             'Rpc-Caller' => 'ruby-client',
             'Rpc-Encoding' => 'thrift',
@@ -356,7 +356,7 @@ module Cadence
 
       def connection
         @connection ||= begin
-          protocol = Thrift::BinaryProtocol.new(transport)
+          protocol = ::Thrift::BinaryProtocol.new(transport)
           CadenceThrift::WorkflowService::Client.new(protocol)
         end
       end

--- a/lib/cadence/execution_options.rb
+++ b/lib/cadence/execution_options.rb
@@ -4,7 +4,7 @@ module Cadence
   class ExecutionOptions
     attr_reader :name, :domain, :task_list, :retry_policy, :timeouts, :headers
 
-    def initialize(object, options = {})
+    def initialize(object, options, defaults = nil)
       @name = options[:name] || object.to_s
       @domain = options[:domain]
       @task_list = options[:task_list]
@@ -21,10 +21,12 @@ module Cadence
         @headers = object.headers.merge(@headers) if object.headers
       end
 
-      @domain ||= Cadence.configuration.domain
-      @task_list ||= Cadence.configuration.task_list
-      @timeouts = Cadence.configuration.timeouts.merge(@timeouts)
-      @headers = Cadence.configuration.headers.merge(@headers)
+      if defaults
+        @domain ||= defaults.domain
+        @task_list ||= defaults.task_list
+        @timeouts = defaults.timeouts.merge(@timeouts)
+        @headers = defaults.headers.merge(@headers)
+      end
 
       freeze
     end

--- a/lib/cadence/worker.rb
+++ b/lib/cadence/worker.rb
@@ -18,14 +18,14 @@ module Cadence
     end
 
     def register_workflow(workflow_class, options = {})
-      execution_options = ExecutionOptions.new(workflow_class, options, config.for_execution)
+      execution_options = ExecutionOptions.new(workflow_class, options, config.default_execution_options)
       key = [execution_options.domain, execution_options.task_list]
 
       @workflows[key].add(execution_options.name, workflow_class)
     end
 
     def register_activity(activity_class, options = {})
-      execution_options = ExecutionOptions.new(activity_class, options, config.for_execution)
+      execution_options = ExecutionOptions.new(activity_class, options, config.default_execution_options)
       key = [execution_options.domain, execution_options.task_list]
 
       @activities[key].add(execution_options.name, activity_class)

--- a/lib/cadence/worker.rb
+++ b/lib/cadence/worker.rb
@@ -1,4 +1,3 @@
-require 'cadence/connection'
 require 'cadence/workflow/poller'
 require 'cadence/activity/poller'
 require 'cadence/execution_options'
@@ -7,7 +6,8 @@ require 'cadence/middleware/entry'
 
 module Cadence
   class Worker
-    def initialize(options = {})
+    def initialize(config = Cadence.configuration, **options)
+      @config = config
       @options = options
       @workflows = Hash.new { |hash, key| hash[key] = ExecutableLookup.new }
       @activities = Hash.new { |hash, key| hash[key] = ExecutableLookup.new }
@@ -18,14 +18,14 @@ module Cadence
     end
 
     def register_workflow(workflow_class, options = {})
-      execution_options = ExecutionOptions.new(workflow_class, options)
+      execution_options = ExecutionOptions.new(workflow_class, options, config.for_execution)
       key = [execution_options.domain, execution_options.task_list]
 
       @workflows[key].add(execution_options.name, workflow_class)
     end
 
     def register_activity(activity_class, options = {})
-      execution_options = ExecutionOptions.new(activity_class, options)
+      execution_options = ExecutionOptions.new(activity_class, options, config.for_execution)
       key = [execution_options.domain, execution_options.task_list]
 
       @activities[key].add(execution_options.name, activity_class)
@@ -67,7 +67,7 @@ module Cadence
 
     private
 
-    attr_reader :options, :activities, :workflows, :pollers,
+    attr_reader :config, :options, :activities, :workflows, :pollers,
                 :decision_middleware, :activity_middleware
 
     def shutting_down?
@@ -75,11 +75,11 @@ module Cadence
     end
 
     def workflow_poller_for(domain, task_list, lookup)
-      Workflow::Poller.new(domain, task_list, lookup.freeze, decision_middleware, options)
+      Workflow::Poller.new(domain, task_list, lookup.freeze, config, decision_middleware, options)
     end
 
     def activity_poller_for(domain, task_list, lookup)
-      Activity::Poller.new(domain, task_list, lookup.freeze, activity_middleware, options)
+      Activity::Poller.new(domain, task_list, lookup.freeze, config, activity_middleware, options)
     end
 
     def trap_signals

--- a/lib/cadence/worker.rb
+++ b/lib/cadence/worker.rb
@@ -1,4 +1,4 @@
-require 'cadence/client'
+require 'cadence/connection'
 require 'cadence/workflow/poller'
 require 'cadence/activity/poller'
 require 'cadence/execution_options'

--- a/lib/cadence/workflow/context.rb
+++ b/lib/cadence/workflow/context.rb
@@ -40,7 +40,7 @@ module Cadence
         options = args.delete(:options) || {}
         input << args unless args.empty?
 
-        execution_options = ExecutionOptions.new(activity_class, options, config.for_execution)
+        execution_options = ExecutionOptions.new(activity_class, options, config.default_execution_options)
 
         decision = Decision::ScheduleActivity.new(
           activity_id: options[:activity_id],
@@ -98,7 +98,7 @@ module Cadence
         options = args.delete(:options) || {}
         input << args unless args.empty?
 
-        execution_options = ExecutionOptions.new(workflow_class, options, config.for_execution)
+        execution_options = ExecutionOptions.new(workflow_class, options, config.default_execution_options)
 
         decision = Decision::StartChildWorkflow.new(
           workflow_id: options[:workflow_id] || SecureRandom.uuid,

--- a/lib/cadence/workflow/context.rb
+++ b/lib/cadence/workflow/context.rb
@@ -15,10 +15,11 @@ require 'cadence/workflow/state_manager'
 module Cadence
   class Workflow
     class Context
-      def initialize(state_manager, dispatcher, metadata)
+      def initialize(state_manager, dispatcher, metadata, config)
         @state_manager = state_manager
         @dispatcher = dispatcher
         @metadata = metadata
+        @config = config
       end
 
       def logger
@@ -39,7 +40,7 @@ module Cadence
         options = args.delete(:options) || {}
         input << args unless args.empty?
 
-        execution_options = ExecutionOptions.new(activity_class, options)
+        execution_options = ExecutionOptions.new(activity_class, options, config.for_execution)
 
         decision = Decision::ScheduleActivity.new(
           activity_id: options[:activity_id],
@@ -97,7 +98,7 @@ module Cadence
         options = args.delete(:options) || {}
         input << args unless args.empty?
 
-        execution_options = ExecutionOptions.new(workflow_class, options)
+        execution_options = ExecutionOptions.new(workflow_class, options, config.for_execution)
 
         decision = Decision::StartChildWorkflow.new(
           workflow_id: options[:workflow_id] || SecureRandom.uuid,
@@ -243,7 +244,7 @@ module Cadence
 
       private
 
-      attr_reader :state_manager, :dispatcher, :metadata
+      attr_reader :state_manager, :dispatcher, :metadata, :config
 
       def schedule_decision(decision)
         state_manager.schedule(decision)

--- a/lib/cadence/workflow/decision_task_processor.rb
+++ b/lib/cadence/workflow/decision_task_processor.rb
@@ -8,13 +8,12 @@ module Cadence
     class DecisionTaskProcessor
       MAX_FAILED_ATTEMPTS = 50
 
-      def initialize(task, domain, workflow_lookup, connection, middleware_chain, config)
+      def initialize(task, domain, workflow_lookup, middleware_chain, config)
         @task = task
         @domain = domain
         @task_token = task.taskToken
         @workflow_name = task.workflowType.name
         @workflow_class = workflow_lookup.find(workflow_name)
-        @connection = connection
         @middleware_chain = middleware_chain
         @config = config
       end
@@ -51,8 +50,12 @@ module Cadence
 
       private
 
-      attr_reader :task, :domain, :task_token, :workflow_name, :workflow_class, :connection,
+      attr_reader :task, :domain, :task_token, :workflow_name, :workflow_class,
         :middleware_chain, :config
+
+      def connection
+        @connection ||= Cadence::Connection.generate(config.for_connection)
+      end
 
       def queue_time_ms
         ((task.startedTimestamp - task.scheduledTimestamp) / 1_000_000).round

--- a/lib/cadence/workflow/executor.rb
+++ b/lib/cadence/workflow/executor.rb
@@ -8,11 +8,12 @@ require 'cadence/workflow/history/event_target'
 module Cadence
   class Workflow
     class Executor
-      def initialize(workflow_class, history)
+      def initialize(workflow_class, history, config)
         @workflow_class = workflow_class
         @dispatcher = Dispatcher.new
         @state_manager = StateManager.new(dispatcher)
         @history = history
+        @config = config
       end
 
       def run
@@ -31,10 +32,10 @@ module Cadence
 
       private
 
-      attr_reader :workflow_class, :dispatcher, :state_manager, :history
+      attr_reader :workflow_class, :dispatcher, :state_manager, :history, :config
 
       def execute_workflow(input, metadata)
-        context = Workflow::Context.new(state_manager, dispatcher, metadata)
+        context = Workflow::Context.new(state_manager, dispatcher, metadata, config)
 
         Fiber.new do
           workflow_class.execute_in_context(context, input)

--- a/lib/cadence/workflow/poller.rb
+++ b/lib/cadence/workflow/poller.rb
@@ -76,12 +76,9 @@ module Cadence
       end
 
       def process(task)
-        connection = Cadence::Connection.generate(config.for_connection)
         middleware_chain = Middleware::Chain.new(middleware)
 
-        DecisionTaskProcessor.new(
-          task, domain, workflow_lookup, connection, middleware_chain, config
-        ).process
+        DecisionTaskProcessor.new(task, domain, workflow_lookup, middleware_chain, config).process
       end
 
       def thread_pool

--- a/lib/cadence/workflow/poller.rb
+++ b/lib/cadence/workflow/poller.rb
@@ -10,10 +10,11 @@ module Cadence
         thread_pool_size: 1
       }.freeze
 
-      def initialize(domain, task_list, workflow_lookup, middleware = [], options = {})
+      def initialize(domain, task_list, workflow_lookup, config, middleware = [], options = {})
         @domain = domain
         @task_list = task_list
         @workflow_lookup = workflow_lookup
+        @config = config
         @middleware = middleware
         @options = DEFAULT_OPTIONS.merge(options)
         @shutting_down = false
@@ -36,10 +37,10 @@ module Cadence
 
       private
 
-      attr_reader :domain, :task_list, :connection, :workflow_lookup, :middleware, :options
+      attr_reader :domain, :task_list, :connection, :workflow_lookup, :config, :middleware, :options
 
       def connection
-        @connection ||= Cadence::Connection.generate(options)
+        @connection ||= Cadence::Connection.generate(config.for_connection, options)
       end
 
       def shutting_down?
@@ -75,10 +76,12 @@ module Cadence
       end
 
       def process(task)
-        connection = Cadence::Connection.generate
+        connection = Cadence::Connection.generate(config.for_connection)
         middleware_chain = Middleware::Chain.new(middleware)
 
-        DecisionTaskProcessor.new(task, domain, workflow_lookup, connection, middleware_chain).process
+        DecisionTaskProcessor.new(
+          task, domain, workflow_lookup, connection, middleware_chain, config
+        ).process
       end
 
       def thread_pool

--- a/lib/cadence/workflow/poller.rb
+++ b/lib/cadence/workflow/poller.rb
@@ -1,4 +1,4 @@
-require 'cadence/client'
+require 'cadence/connection'
 require 'cadence/thread_pool'
 require 'cadence/middleware/chain'
 require 'cadence/workflow/decision_task_processor'
@@ -36,10 +36,10 @@ module Cadence
 
       private
 
-      attr_reader :domain, :task_list, :client, :workflow_lookup, :middleware, :options
+      attr_reader :domain, :task_list, :connection, :workflow_lookup, :middleware, :options
 
-      def client
-        @client ||= Cadence::Client.generate(options)
+      def connection
+        @connection ||= Cadence::Connection.generate(options)
       end
 
       def shutting_down?
@@ -68,17 +68,17 @@ module Cadence
       end
 
       def poll_for_task
-        client.poll_for_decision_task(domain: domain, task_list: task_list)
+        connection.poll_for_decision_task(domain: domain, task_list: task_list)
       rescue StandardError => error
         Cadence.logger.error("Unable to poll for a decision task: #{error.inspect}")
         nil
       end
 
       def process(task)
-        client = Cadence::Client.generate
+        connection = Cadence::Connection.generate
         middleware_chain = Middleware::Chain.new(middleware)
 
-        DecisionTaskProcessor.new(task, domain, workflow_lookup, client, middleware_chain).process
+        DecisionTaskProcessor.new(task, domain, workflow_lookup, connection, middleware_chain).process
       end
 
       def thread_pool

--- a/spec/unit/lib/cadence/activity/context_spec.rb
+++ b/spec/unit/lib/cadence/activity/context_spec.rb
@@ -1,21 +1,22 @@
 require 'cadence/activity/context'
 require 'cadence/metadata/activity'
+require 'cadence/connection/thrift'
 
 describe Cadence::Activity::Context do
-  let(:client) { instance_double('Cadence::Client::ThriftClient') }
+  let(:connection) { instance_double('Cadence::Connection::Thrift') }
   let(:metadata_hash) { Fabricate(:activity_metadata).to_h }
   let(:metadata) { Cadence::Metadata::Activity.new(metadata_hash) }
   let(:task_token) { SecureRandom.uuid }
 
-  subject { described_class.new(client, metadata) }
+  subject { described_class.new(connection, metadata) }
 
   describe '#heartbeat' do
-    before { allow(client).to receive(:record_activity_task_heartbeat) }
+    before { allow(connection).to receive(:record_activity_task_heartbeat) }
 
     it 'records heartbeat' do
       subject.heartbeat
 
-      expect(client)
+      expect(connection)
         .to have_received(:record_activity_task_heartbeat)
         .with(task_token: metadata.task_token, details: nil)
     end
@@ -23,7 +24,7 @@ describe Cadence::Activity::Context do
     it 'records heartbeat with details' do
       subject.heartbeat(foo: :bar)
 
-      expect(client)
+      expect(connection)
         .to have_received(:record_activity_task_heartbeat)
         .with(task_token: metadata.task_token, details: { foo: :bar })
     end
@@ -37,7 +38,7 @@ describe Cadence::Activity::Context do
 
   describe '#async?' do
     subject { context.async? }
-    let(:context) { described_class.new(client, metadata) }
+    let(:context) { described_class.new(connection, metadata) }
 
     context 'when context is sync' do
       it { is_expected.to eq(false) }

--- a/spec/unit/lib/cadence/activity/poller_spec.rb
+++ b/spec/unit/lib/cadence/activity/poller_spec.rb
@@ -115,7 +115,7 @@ describe Cadence::Activity::Poller do
 
         expect(Cadence::Activity::TaskProcessor)
           .to have_received(:new)
-          .with(task, domain, lookup, connection, middleware_chain)
+          .with(task, domain, lookup, middleware_chain, config)
         expect(task_processor).to have_received(:process)
       end
 
@@ -138,7 +138,7 @@ describe Cadence::Activity::Poller do
           expect(Cadence::Middleware::Chain).to have_received(:new).with(middleware)
           expect(Cadence::Activity::TaskProcessor)
             .to have_received(:new)
-            .with(task, domain, lookup, connection, middleware_chain)
+            .with(task, domain, lookup, middleware_chain, config)
         end
       end
     end

--- a/spec/unit/lib/cadence/activity/poller_spec.rb
+++ b/spec/unit/lib/cadence/activity/poller_spec.rb
@@ -74,7 +74,7 @@ describe Cadence::Activity::Poller do
 
         expect(Cadence::Connection)
           .to have_received(:generate)
-          .with(an_instance_of(Cadence::Configuration::Connection), options)
+          .with(config.for_connection, options)
       end
 
       it 'creates thread pool of a specified size' do

--- a/spec/unit/lib/cadence/activity/poller_spec.rb
+++ b/spec/unit/lib/cadence/activity/poller_spec.rb
@@ -2,7 +2,7 @@ require 'cadence/activity/poller'
 require 'cadence/middleware/entry'
 
 describe Cadence::Activity::Poller do
-  let(:client) { instance_double('Cadence::Client::ThriftClient') }
+  let(:connection) { instance_double('Cadence::Connection::Thrift') }
   let(:domain) { 'test-domain' }
   let(:task_list) { 'test-task-list' }
   let(:lookup) { instance_double('Cadence::ExecutableLookup') }
@@ -15,10 +15,10 @@ describe Cadence::Activity::Poller do
   subject { described_class.new(domain, task_list, lookup, middleware) }
 
   before do
-    allow(Cadence::Client).to receive(:generate).and_return(client)
+    allow(Cadence::Connection).to receive(:generate).and_return(connection)
     allow(Cadence::ThreadPool).to receive(:new).and_return(thread_pool)
     allow(Cadence::Middleware::Chain).to receive(:new).and_return(middleware_chain)
-    allow(client).to receive(:poll_for_activity_task).and_return(nil)
+    allow(connection).to receive(:poll_for_activity_task).and_return(nil)
     allow(Cadence.metrics).to receive(:timing)
   end
 
@@ -31,7 +31,7 @@ describe Cadence::Activity::Poller do
       # stop poller before inspecting
       subject.stop; subject.wait
 
-      expect(client)
+      expect(connection)
         .to have_received(:poll_for_activity_task)
         .with(domain: domain, task_list: task_list)
         .twice
@@ -64,13 +64,13 @@ describe Cadence::Activity::Poller do
         allow(subject).to receive(:shutting_down?).and_return(false, true)
       end
 
-      it 'passes options to the client' do
+      it 'passes options to the connection' do
         subject.start
 
         # stop poller before inspecting
         subject.stop; subject.wait
 
-        expect(Cadence::Client).to have_received(:generate).with(options)
+        expect(Cadence::Connection).to have_received(:generate).with(options)
       end
 
       it 'creates thread pool of a specified size' do
@@ -89,7 +89,7 @@ describe Cadence::Activity::Poller do
 
       before do
         allow(subject).to receive(:shutting_down?).and_return(false, true)
-        allow(client).to receive(:poll_for_activity_task).and_return(task)
+        allow(connection).to receive(:poll_for_activity_task).and_return(task)
         allow(Cadence::Activity::TaskProcessor).to receive(:new).and_return(task_processor)
         allow(thread_pool).to receive(:schedule).and_yield
       end
@@ -111,7 +111,7 @@ describe Cadence::Activity::Poller do
 
         expect(Cadence::Activity::TaskProcessor)
           .to have_received(:new)
-          .with(task, domain, lookup, client, middleware_chain)
+          .with(task, domain, lookup, connection, middleware_chain)
         expect(task_processor).to have_received(:process)
       end
 
@@ -134,15 +134,15 @@ describe Cadence::Activity::Poller do
           expect(Cadence::Middleware::Chain).to have_received(:new).with(middleware)
           expect(Cadence::Activity::TaskProcessor)
             .to have_received(:new)
-            .with(task, domain, lookup, client, middleware_chain)
+            .with(task, domain, lookup, connection, middleware_chain)
         end
       end
     end
 
-    context 'when client is unable to poll' do
+    context 'when connection is unable to poll' do
       before do
         allow(subject).to receive(:shutting_down?).and_return(false, true)
-        allow(client).to receive(:poll_for_activity_task).and_raise(StandardError)
+        allow(connection).to receive(:poll_for_activity_task).and_raise(StandardError)
       end
 
       it 'logs' do

--- a/spec/unit/lib/cadence/activity/task_processor_spec.rb
+++ b/spec/unit/lib/cadence/activity/task_processor_spec.rb
@@ -1,8 +1,9 @@
 require 'cadence/activity/task_processor'
 require 'cadence/middleware/chain'
+require 'cadence/configuration'
 
 describe Cadence::Activity::TaskProcessor do
-  subject { described_class.new(task, domain, lookup, connection, middleware_chain) }
+  subject { described_class.new(task, domain, lookup, middleware_chain, config) }
 
   let(:domain) { 'test-domain' }
   let(:lookup) { instance_double('Cadence::ExecutableLookup', find: nil) }
@@ -13,12 +14,17 @@ describe Cadence::Activity::TaskProcessor do
   let(:activity_name) { 'TestActivity' }
   let(:connection) { instance_double('Cadence::Connection::Thrift') }
   let(:middleware_chain) { Cadence::Middleware::Chain.new }
+  let(:config) { Cadence::Configuration.new }
   let(:input) { ['arg1', 'arg2'] }
 
   describe '#process' do
     let(:context) { instance_double('Cadence::Activity::Context', async?: false) }
 
     before do
+      allow(Cadence::Connection)
+        .to receive(:generate)
+        .with(config.for_connection)
+        .and_return(connection)
       allow(Cadence::Metadata)
         .to receive(:generate)
         .with(Cadence::Metadata::ACTIVITY_TYPE, task, domain)

--- a/spec/unit/lib/cadence/testing_spec.rb
+++ b/spec/unit/lib/cadence/testing_spec.rb
@@ -11,18 +11,18 @@ describe Cadence::Testing::CadenceOverride do
 
   context 'when testing mode is disabled' do
     describe 'Cadence.start_workflow' do
-      let(:client) { instance_double('Cadence::Client::ThriftClient') }
+      let(:connection) { instance_double('Cadence::Connection::Thrift') }
       let(:response) { CadenceThrift::StartWorkflowExecutionResponse.new(runId: 'xxx') }
 
-      before { allow(Cadence::Client).to receive(:generate).and_return(client) }
-      after { Cadence.remove_instance_variable(:@client) }
+      before { allow(Cadence::Connection).to receive(:generate).and_return(connection) }
+      after { Cadence.remove_instance_variable(:@connection) }
 
       it 'invokes original implementation' do
-        allow(client).to receive(:start_workflow_execution).and_return(response)
+        allow(connection).to receive(:start_workflow_execution).and_return(response)
 
         Cadence.start_workflow(TestCadenceOverrideWorkflow)
 
-        expect(client)
+        expect(connection)
           .to have_received(:start_workflow_execution)
           .with(hash_including(workflow_name: 'TestCadenceOverrideWorkflow'))
       end

--- a/spec/unit/lib/cadence/worker_spec.rb
+++ b/spec/unit/lib/cadence/worker_spec.rb
@@ -1,8 +1,12 @@
 require 'cadence/worker'
 require 'cadence/workflow'
 require 'cadence/activity'
+require 'cadence/configuration'
 
 describe Cadence::Worker do
+  subject { described_class.new(config) }
+  let(:config) { Cadence::Configuration.new }
+
   class TestWorkerWorkflow < Cadence::Workflow
     domain 'default-domain'
     task_list 'default-task-list'
@@ -134,22 +138,22 @@ describe Cadence::Worker do
 
       allow(Cadence::Workflow::Poller)
         .to receive(:new)
-        .with('default-domain', 'default-task-list', an_instance_of(Cadence::ExecutableLookup), [], {})
+        .with('default-domain', 'default-task-list', an_instance_of(Cadence::ExecutableLookup), config, [], {})
         .and_return(workflow_poller_1)
 
       allow(Cadence::Workflow::Poller)
         .to receive(:new)
-        .with('other-domain', 'default-task-list', an_instance_of(Cadence::ExecutableLookup), [], {})
+        .with('other-domain', 'default-task-list', an_instance_of(Cadence::ExecutableLookup), config, [], {})
         .and_return(workflow_poller_2)
 
       allow(Cadence::Activity::Poller)
         .to receive(:new)
-        .with('default-domain', 'default-task-list', an_instance_of(Cadence::ExecutableLookup), [], {})
+        .with('default-domain', 'default-task-list', an_instance_of(Cadence::ExecutableLookup), config, [], {})
         .and_return(activity_poller_1)
 
       allow(Cadence::Activity::Poller)
         .to receive(:new)
-        .with('default-domain', 'other-task-list', an_instance_of(Cadence::ExecutableLookup), [], {})
+        .with('default-domain', 'other-task-list', an_instance_of(Cadence::ExecutableLookup), config, [], {})
         .and_return(activity_poller_2)
 
       subject.register_workflow(TestWorkerWorkflow)
@@ -166,7 +170,7 @@ describe Cadence::Worker do
     end
 
     context 'with options' do
-      subject { described_class.new(options) }
+      subject { described_class.new(config, options) }
       let(:options) { { polling_ttl: 42, thread_pool_size: 42 } }
 
       before do
@@ -184,6 +188,7 @@ describe Cadence::Worker do
             'default-domain',
             'default-task-list',
             an_instance_of(Cadence::ExecutableLookup),
+            config,
             [],
             options
           )
@@ -214,12 +219,12 @@ describe Cadence::Worker do
 
         allow(Cadence::Workflow::Poller)
           .to receive(:new)
-          .with('default-domain', 'default-task-list', an_instance_of(Cadence::ExecutableLookup), [entry_1], {})
+          .with('default-domain', 'default-task-list', an_instance_of(Cadence::ExecutableLookup), config, [entry_1], {})
           .and_return(workflow_poller_1)
 
         allow(Cadence::Activity::Poller)
           .to receive(:new)
-          .with('default-domain', 'default-task-list', an_instance_of(Cadence::ExecutableLookup), [entry_2], {})
+          .with('default-domain', 'default-task-list', an_instance_of(Cadence::ExecutableLookup), config, [entry_2], {})
           .and_return(activity_poller_1)
 
         subject.register_workflow(TestWorkerWorkflow)

--- a/spec/unit/lib/cadence/workflow/context_spec.rb
+++ b/spec/unit/lib/cadence/workflow/context_spec.rb
@@ -1,15 +1,17 @@
 require 'cadence/testing/local_workflow_context'
 require 'cadence/workflow/context'
 require 'cadence/workflow/dispatcher'
+require 'cadence/configuration'
 
 describe Cadence::Workflow::Context do
     let(:state_manager) { instance_double('Cadence::Workflow::StateManager') }
     let(:dispatcher) { Cadence::Workflow::Dispatcher.new }
-    let(:metadata_hash) do 
+    let(:metadata_hash) do
         {name: 'TestWorkflow', run_id: SecureRandom.uuid, attempt: 0, timeouts: { execution: 15, task: 10 } }
     end
     let(:metadata) { Cadence::Metadata::Workflow.new(metadata_hash) }
-    let(:context) { described_class.new(state_manager, dispatcher, metadata) }
+    let(:config) { Cadence::Configuration.new }
+    let(:context) { described_class.new(state_manager, dispatcher, metadata, config) }
 
     describe '.sleep_until' do
         let(:start_time) { Time.now}

--- a/spec/unit/lib/cadence/workflow/decision_task_processor_spec.rb
+++ b/spec/unit/lib/cadence/workflow/decision_task_processor_spec.rb
@@ -3,11 +3,12 @@ require 'cadence/workflow'
 require 'cadence/executable_lookup'
 require 'cadence/connection/thrift'
 require 'cadence/middleware/chain'
+require 'cadence/configuration'
 
 describe Cadence::Workflow::DecisionTaskProcessor do
   class TestWorkflow < Cadence::Workflow; end
 
-  subject { described_class.new(task, domain, lookup, connection, middleware_chain) }
+  subject { described_class.new(task, domain, lookup, connection, middleware_chain, config) }
 
   let(:task) { Fabricate(:decision_task_thrift) }
   let(:domain) { 'test-domain' }
@@ -21,6 +22,7 @@ describe Cadence::Workflow::DecisionTaskProcessor do
   end
   let(:middleware_chain) { Cadence::Middleware::Chain.new }
   let(:executor) { instance_double(Cadence::Workflow::Executor, run: []) }
+  let(:config) { Cadence::Configuration.new }
 
   before do
     allow(Cadence.metrics).to receive(:timing)
@@ -35,7 +37,7 @@ describe Cadence::Workflow::DecisionTaskProcessor do
 
       allow(Cadence::Workflow::Executor)
         .to receive(:new)
-        .with(TestWorkflow, an_instance_of(Cadence::Workflow::History))
+        .with(TestWorkflow, an_instance_of(Cadence::Workflow::History), config)
         .and_return(executor)
     end
 

--- a/spec/unit/lib/cadence/workflow/decision_task_processor_spec.rb
+++ b/spec/unit/lib/cadence/workflow/decision_task_processor_spec.rb
@@ -1,20 +1,20 @@
 require 'cadence/workflow/decision_task_processor'
 require 'cadence/workflow'
 require 'cadence/executable_lookup'
-require 'cadence/client/thrift_client'
+require 'cadence/connection/thrift'
 require 'cadence/middleware/chain'
 
 describe Cadence::Workflow::DecisionTaskProcessor do
   class TestWorkflow < Cadence::Workflow; end
 
-  subject { described_class.new(task, domain, lookup, client, middleware_chain) }
+  subject { described_class.new(task, domain, lookup, connection, middleware_chain) }
 
   let(:task) { Fabricate(:decision_task_thrift) }
   let(:domain) { 'test-domain' }
   let(:lookup) { Cadence::ExecutableLookup.new }
-  let(:client) do
+  let(:connection) do
     instance_double(
-      Cadence::Client::ThriftClient,
+      Cadence::Connection::Thrift,
       respond_decision_task_completed: nil,
       respond_decision_task_failed: nil
     )
@@ -61,7 +61,7 @@ describe Cadence::Workflow::DecisionTaskProcessor do
     it 'completes the decision task' do
       subject.process
 
-      expect(client)
+      expect(connection)
         .to have_received(:respond_decision_task_completed)
         .with(task_token: task.taskToken, decisions: [])
     end
@@ -84,7 +84,7 @@ describe Cadence::Workflow::DecisionTaskProcessor do
       let(:history_2) { Fabricate(:worklfow_execution_history_thrift, nextPageToken: nil) }
 
       before do
-        allow(client)
+        allow(connection)
           .to receive(:get_workflow_execution_history)
           .and_return(history_1, history_2)
       end
@@ -92,7 +92,7 @@ describe Cadence::Workflow::DecisionTaskProcessor do
       it 'fetches missing history pages' do
         subject.process
 
-        expect(client)
+        expect(connection)
           .to have_received(:get_workflow_execution_history)
           .with(
             domain: domain,
@@ -101,7 +101,7 @@ describe Cadence::Workflow::DecisionTaskProcessor do
             next_page_token: task.nextPageToken
           )
 
-        expect(client)
+        expect(connection)
           .to have_received(:get_workflow_execution_history)
           .with(
             domain: domain,
@@ -123,7 +123,7 @@ describe Cadence::Workflow::DecisionTaskProcessor do
 
     context 'when unable to complete a workflow' do
       before do
-        allow(client)
+        allow(connection)
           .to receive(:respond_decision_task_completed)
           .and_raise(StandardError, 'Host unreachable')
       end
@@ -146,7 +146,7 @@ describe Cadence::Workflow::DecisionTaskProcessor do
     it 'fails the decision task' do
       subject.process
 
-      expect(client)
+      expect(connection)
         .to have_received(:respond_decision_task_failed)
         .with(
           task_token: task.taskToken,
@@ -176,7 +176,7 @@ describe Cadence::Workflow::DecisionTaskProcessor do
 
       subject.process
 
-      expect(client).not_to have_received(:respond_decision_task_failed)
+      expect(connection).not_to have_received(:respond_decision_task_failed)
     end
   end
 end

--- a/spec/unit/lib/cadence/workflow/decision_task_processor_spec.rb
+++ b/spec/unit/lib/cadence/workflow/decision_task_processor_spec.rb
@@ -8,7 +8,7 @@ require 'cadence/configuration'
 describe Cadence::Workflow::DecisionTaskProcessor do
   class TestWorkflow < Cadence::Workflow; end
 
-  subject { described_class.new(task, domain, lookup, connection, middleware_chain, config) }
+  subject { described_class.new(task, domain, lookup, middleware_chain, config) }
 
   let(:task) { Fabricate(:decision_task_thrift) }
   let(:domain) { 'test-domain' }
@@ -25,6 +25,10 @@ describe Cadence::Workflow::DecisionTaskProcessor do
   let(:config) { Cadence::Configuration.new }
 
   before do
+    allow(Cadence::Connection)
+      .to receive(:generate)
+      .with(config.for_connection)
+      .and_return(connection)
     allow(Cadence.metrics).to receive(:timing)
     allow(Cadence.logger).to receive(:info)
     allow(Cadence.logger).to receive(:error)

--- a/spec/unit/lib/cadence/workflow/poller_spec.rb
+++ b/spec/unit/lib/cadence/workflow/poller_spec.rb
@@ -117,7 +117,7 @@ describe Cadence::Workflow::Poller do
 
         expect(Cadence::Workflow::DecisionTaskProcessor)
           .to have_received(:new)
-          .with(task, domain, lookup, connection, middleware_chain, config)
+          .with(task, domain, lookup, middleware_chain, config)
         expect(task_processor).to have_received(:process)
       end
 
@@ -140,7 +140,7 @@ describe Cadence::Workflow::Poller do
           expect(Cadence::Middleware::Chain).to have_received(:new).with(middleware)
           expect(Cadence::Workflow::DecisionTaskProcessor)
             .to have_received(:new)
-            .with(task, domain, lookup, connection, middleware_chain, config)
+            .with(task, domain, lookup, middleware_chain, config)
         end
       end
     end

--- a/spec/unit/lib/cadence/workflow/poller_spec.rb
+++ b/spec/unit/lib/cadence/workflow/poller_spec.rb
@@ -74,7 +74,7 @@ describe Cadence::Workflow::Poller do
 
         expect(Cadence::Connection)
           .to have_received(:generate)
-          .with(an_instance_of(Cadence::Configuration::Connection), options)
+          .with(config.for_connection, options)
       end
 
       it 'creates thread pool of a specified size' do


### PR DESCRIPTION
I'm working on a bigger change that will turn Cadence into an initializable class rather than using a single global instance. This will allow connecting your app to multiple clusters (this is handy for easy migrating from one Cadence cluster to another or more exotic solutions such as client-side sharding).

This is the first step which makes configuration local, passed to all classes that are using it