### PR TITLE
[Feature] Initializable Cadence client

### DIFF
--- a/lib/cadence.rb
+++ b/lib/cadence.rb
@@ -1,137 +1,25 @@
 require 'securerandom'
+require 'forwardable'
 require 'cadence/configuration'
-require 'cadence/execution_options'
-require 'cadence/connection'
-require 'cadence/activity'
-require 'cadence/activity/async_token'
-require 'cadence/workflow'
-require 'cadence/workflow/history'
-require 'cadence/workflow/execution_info'
+require 'cadence/client'
 require 'cadence/metrics'
 
 module Cadence
+  extend SingleForwardable
+
+  def_delegators :default_client, # target
+                 :start_workflow,
+                 :schedule_workflow,
+                 :register_domain,
+                 :signal_workflow,
+                 :reset_workflow,
+                 :terminate_workflow,
+                 :fetch_workflow_execution_info,
+                 :complete_activity,
+                 :fail_activity,
+                 :get_workflow_history
+
   class << self
-    def start_workflow(workflow, *input, **args)
-      options = args.delete(:options) || {}
-      input << args unless args.empty?
-
-      execution_options = ExecutionOptions.new(workflow, options, config.default_execution_options)
-      workflow_id = options[:workflow_id] || SecureRandom.uuid
-
-      response = connection.start_workflow_execution(
-        domain: execution_options.domain,
-        workflow_id: workflow_id,
-        workflow_name: execution_options.name,
-        task_list: execution_options.task_list,
-        input: input,
-        execution_timeout: execution_options.timeouts[:execution],
-        task_timeout: execution_options.timeouts[:task],
-        workflow_id_reuse_policy: options[:workflow_id_reuse_policy],
-        headers: execution_options.headers
-      )
-
-      response.runId
-    end
-
-    def schedule_workflow(workflow, cron_schedule, *input, **args)
-      options = args.delete(:options) || {}
-      input << args unless args.empty?
-
-      execution_options = ExecutionOptions.new(workflow, options, config.default_execution_options)
-      workflow_id = options[:workflow_id] || SecureRandom.uuid
-
-      response = connection.start_workflow_execution(
-        domain: execution_options.domain,
-        workflow_id: workflow_id,
-        workflow_name: execution_options.name,
-        task_list: execution_options.task_list,
-        input: input,
-        execution_timeout: execution_options.timeouts[:execution],
-        task_timeout: execution_options.timeouts[:task],
-        workflow_id_reuse_policy: options[:workflow_id_reuse_policy],
-        headers: execution_options.headers,
-        cron_schedule: cron_schedule
-      )
-
-      response.runId
-    end
-
-    def register_domain(name, description = nil)
-      connection.register_domain(name: name, description: description)
-    rescue CadenceThrift::DomainAlreadyExistsError
-      nil
-    end
-
-    def signal_workflow(workflow, signal, workflow_id, run_id, input = nil)
-      connection.signal_workflow_execution(
-        domain: workflow.domain, # TODO: allow passing domain instead
-        workflow_id: workflow_id,
-        run_id: run_id,
-        signal: signal,
-        input: input
-      )
-    end
-
-    def reset_workflow(domain, workflow_id, run_id, decision_task_id: nil, reason: 'manual reset')
-      decision_task_id ||= get_last_completed_decision_task(domain, workflow_id, run_id)
-      raise Error, 'Could not find a completed decision task event' unless decision_task_id
-
-      response = connection.reset_workflow_execution(
-        domain: domain,
-        workflow_id: workflow_id,
-        run_id: run_id,
-        reason: reason,
-        decision_task_event_id: decision_task_id
-      )
-
-      response.runId
-    end
-
-    def terminate_workflow(domain, workflow_id, run_id, reason: 'manual termination', details: nil)
-      connection.terminate_workflow_execution(
-        domain: domain,
-        workflow_id: workflow_id,
-        run_id: run_id,
-        reason: reason,
-        details: details
-      )
-    end
-
-    def fetch_workflow_execution_info(domain, workflow_id, run_id)
-      response = connection.describe_workflow_execution(
-        domain: domain,
-        workflow_id: workflow_id,
-        run_id: run_id
-      )
-
-      Workflow::ExecutionInfo.generate_from(response.workflowExecutionInfo)
-    end
-
-    def complete_activity(async_token, result = nil)
-      details = Activity::AsyncToken.decode(async_token)
-
-      connection.respond_activity_task_completed_by_id(
-        domain: details.domain,
-        activity_id: details.activity_id,
-        workflow_id: details.workflow_id,
-        run_id: details.run_id,
-        result: result
-      )
-    end
-
-    def fail_activity(async_token, error)
-      details = Activity::AsyncToken.decode(async_token)
-
-      connection.respond_activity_task_failed_by_id(
-        domain: details.domain,
-        activity_id: details.activity_id,
-        workflow_id: details.workflow_id,
-        run_id: details.run_id,
-        reason: error.class.name,
-        details: error.message
-      )
-    end
-
     def configure(&block)
       yield config
     end
@@ -149,35 +37,14 @@ module Cadence
       @metrics ||= Metrics.new(config.metrics_adapter)
     end
 
-    def get_workflow_history(domain:, workflow_id:, run_id:)
-      history_response = connection.get_workflow_execution_history(
-        domain: domain,
-        workflow_id: workflow_id,
-        run_id: run_id
-      )
-      Workflow::History.new(history_response.history.events)
-    end
-
     private
+
+    def default_client
+      @default_client ||= Client.new(config)
+    end
 
     def config
       @config ||= Configuration.new
-    end
-
-    def connection
-      @connection ||= Cadence::Connection.generate(config.for_connection)
-    end
-
-    def get_last_completed_decision_task(domain, workflow_id, run_id)
-      history = get_workflow_history(
-        domain: domain,
-        workflow_id: workflow_id,
-        run_id: run_id
-      )
-
-      decision_task_event = history.last_completed_decision_task
-
-      decision_task_event&.id
     end
   end
 end

--- a/lib/cadence/client.rb
+++ b/lib/cadence/client.rb
@@ -1,0 +1,163 @@
+require 'cadence/execution_options'
+require 'cadence/connection'
+require 'cadence/activity'
+require 'cadence/activity/async_token'
+require 'cadence/workflow'
+require 'cadence/workflow/history'
+require 'cadence/workflow/execution_info'
+
+module Cadence
+  class Client
+    def initialize(config)
+      @config = config
+    end
+
+    def start_workflow(workflow, *input, **args)
+      options = args.delete(:options) || {}
+      input << args unless args.empty?
+
+      execution_options = ExecutionOptions.new(workflow, options, config.default_execution_options)
+      workflow_id = options[:workflow_id] || SecureRandom.uuid
+
+      response = connection.start_workflow_execution(
+        domain: execution_options.domain,
+        workflow_id: workflow_id,
+        workflow_name: execution_options.name,
+        task_list: execution_options.task_list,
+        input: input,
+        execution_timeout: execution_options.timeouts[:execution],
+        task_timeout: execution_options.timeouts[:task],
+        workflow_id_reuse_policy: options[:workflow_id_reuse_policy],
+        headers: execution_options.headers
+      )
+
+      response.runId
+    end
+
+    def schedule_workflow(workflow, cron_schedule, *input, **args)
+      options = args.delete(:options) || {}
+      input << args unless args.empty?
+
+      execution_options = ExecutionOptions.new(workflow, options, config.default_execution_options)
+      workflow_id = options[:workflow_id] || SecureRandom.uuid
+
+      response = connection.start_workflow_execution(
+        domain: execution_options.domain,
+        workflow_id: workflow_id,
+        workflow_name: execution_options.name,
+        task_list: execution_options.task_list,
+        input: input,
+        execution_timeout: execution_options.timeouts[:execution],
+        task_timeout: execution_options.timeouts[:task],
+        workflow_id_reuse_policy: options[:workflow_id_reuse_policy],
+        headers: execution_options.headers,
+        cron_schedule: cron_schedule
+      )
+
+      response.runId
+    end
+
+    def register_domain(name, description = nil)
+      connection.register_domain(name: name, description: description)
+    rescue CadenceThrift::DomainAlreadyExistsError
+      nil
+    end
+
+    def signal_workflow(workflow, signal, workflow_id, run_id, input = nil)
+      connection.signal_workflow_execution(
+        domain: workflow.domain, # TODO: allow passing domain instead
+        workflow_id: workflow_id,
+        run_id: run_id,
+        signal: signal,
+        input: input
+      )
+    end
+
+    def reset_workflow(domain, workflow_id, run_id, decision_task_id: nil, reason: 'manual reset')
+      decision_task_id ||= get_last_completed_decision_task(domain, workflow_id, run_id)
+      raise Error, 'Could not find a completed decision task event' unless decision_task_id
+
+      response = connection.reset_workflow_execution(
+        domain: domain,
+        workflow_id: workflow_id,
+        run_id: run_id,
+        reason: reason,
+        decision_task_event_id: decision_task_id
+      )
+
+      response.runId
+    end
+
+    def terminate_workflow(domain, workflow_id, run_id, reason: 'manual termination', details: nil)
+      connection.terminate_workflow_execution(
+        domain: domain,
+        workflow_id: workflow_id,
+        run_id: run_id,
+        reason: reason,
+        details: details
+      )
+    end
+
+    def fetch_workflow_execution_info(domain, workflow_id, run_id)
+      response = connection.describe_workflow_execution(
+        domain: domain,
+        workflow_id: workflow_id,
+        run_id: run_id
+      )
+
+      Workflow::ExecutionInfo.generate_from(response.workflowExecutionInfo)
+    end
+
+    def complete_activity(async_token, result = nil)
+      details = Activity::AsyncToken.decode(async_token)
+
+      connection.respond_activity_task_completed_by_id(
+        domain: details.domain,
+        activity_id: details.activity_id,
+        workflow_id: details.workflow_id,
+        run_id: details.run_id,
+        result: result
+      )
+    end
+
+    def fail_activity(async_token, error)
+      details = Activity::AsyncToken.decode(async_token)
+
+      connection.respond_activity_task_failed_by_id(
+        domain: details.domain,
+        activity_id: details.activity_id,
+        workflow_id: details.workflow_id,
+        run_id: details.run_id,
+        reason: error.class.name,
+        details: error.message
+      )
+    end
+
+    def get_workflow_history(domain:, workflow_id:, run_id:)
+      history_response = connection.get_workflow_execution_history(
+        domain: domain,
+        workflow_id: workflow_id,
+        run_id: run_id
+      )
+      Workflow::History.new(history_response.history.events)
+    end
+
+    private
+
+    attr_reader :config
+
+    def connection
+      @connection ||= Cadence::Connection.generate(config.for_connection)
+    end
+
+    def get_last_completed_decision_task(domain, workflow_id, run_id)
+      history = get_workflow_history(
+        domain: domain,
+        workflow_id: workflow_id,
+        run_id: run_id
+      )
+
+      history.last_completed_decision_task&.id
+    end
+  end
+end

--- a/lib/cadence/testing.rb
+++ b/lib/cadence/testing.rb
@@ -46,5 +46,5 @@ module Cadence
   end
 end
 
-Cadence.singleton_class.prepend Cadence::Testing::CadenceOverride
+Cadence::Client.prepend Cadence::Testing::CadenceOverride
 Cadence::Workflow.extend Cadence::Testing::WorkflowOverride

--- a/spec/unit/lib/cadence/client_spec.rb
+++ b/spec/unit/lib/cadence/client_spec.rb
@@ -1,0 +1,424 @@
+require 'cadence/client'
+require 'cadence/configuration'
+require 'cadence/workflow'
+require 'cadence/connection/thrift'
+
+describe Cadence::Client do
+  subject { described_class.new(config) }
+
+  let(:config) { Cadence::Configuration.new }
+  let(:connection) { instance_double(Cadence::Connection::Thrift) }
+
+  before do
+    allow(Cadence::Connection)
+      .to receive(:generate)
+      .with(config.for_connection)
+      .and_return(connection)
+  end
+  after { subject.remove_instance_variable(:@connection) }
+
+  describe '#start_workflow' do
+    let(:cadence_response) do
+      CadenceThrift::StartWorkflowExecutionResponse.new(runId: 'xxx')
+    end
+
+    before { allow(connection).to receive(:start_workflow_execution).and_return(cadence_response) }
+
+    context 'using a workflow class' do
+      class TestStartWorkflow < Cadence::Workflow
+        domain 'default-test-domain'
+        task_list 'default-test-task-list'
+      end
+
+      it 'returns run_id' do
+        result = subject.start_workflow(TestStartWorkflow, 42)
+
+        expect(result).to eq(cadence_response.runId)
+      end
+
+      it 'starts a workflow using the default options' do
+        subject.start_workflow(TestStartWorkflow, 42)
+
+        expect(connection)
+          .to have_received(:start_workflow_execution)
+          .with(
+            domain: 'default-test-domain',
+            workflow_id: an_instance_of(String),
+            workflow_name: 'TestStartWorkflow',
+            task_list: 'default-test-task-list',
+            input: [42],
+            task_timeout: Cadence.configuration.timeouts[:task],
+            execution_timeout: Cadence.configuration.timeouts[:execution],
+            workflow_id_reuse_policy: nil,
+            headers: {}
+          )
+      end
+
+      it 'starts a workflow using the options specified' do
+        subject.start_workflow(
+          TestStartWorkflow,
+          42,
+          options: {
+            name: 'test-workflow',
+            domain: 'test-domain',
+            task_list: 'test-task-list',
+            headers: { 'Foo' => 'Bar' }
+          }
+        )
+
+        expect(connection)
+          .to have_received(:start_workflow_execution)
+          .with(
+            domain: 'test-domain',
+            workflow_id: an_instance_of(String),
+            workflow_name: 'test-workflow',
+            task_list: 'test-task-list',
+            input: [42],
+            task_timeout: Cadence.configuration.timeouts[:task],
+            execution_timeout: Cadence.configuration.timeouts[:execution],
+            workflow_id_reuse_policy: nil,
+            headers: { 'Foo' => 'Bar' }
+          )
+      end
+
+      it 'starts a cron workflow' do
+        subject.schedule_workflow(
+          TestStartWorkflow,
+          '* * * * *',
+          42,
+          options: {
+            name: 'test-workflow',
+            domain: 'test-domain',
+            task_list: 'test-task-list',
+            headers: { 'Foo' => 'Bar' },
+
+          }
+        )
+
+        expect(connection)
+          .to have_received(:start_workflow_execution)
+          .with(
+            domain: 'test-domain',
+            workflow_id: an_instance_of(String),
+            workflow_name: 'test-workflow',
+            task_list: 'test-task-list',
+            cron_schedule: '* * * * *',
+            input: [42],
+            task_timeout: Cadence.configuration.timeouts[:task],
+            execution_timeout: Cadence.configuration.timeouts[:execution],
+            workflow_id_reuse_policy: nil,
+            headers: { 'Foo' => 'Bar' }
+          )
+      end
+
+      it 'starts a workflow using a mix of input, keyword arguments and options' do
+        subject.start_workflow(
+          TestStartWorkflow,
+          42,
+          arg_1: 1,
+          arg_2: 2,
+          options: { name: 'test-workflow' }
+        )
+
+        expect(connection)
+          .to have_received(:start_workflow_execution)
+          .with(
+            domain: 'default-test-domain',
+            workflow_id: an_instance_of(String),
+            workflow_name: 'test-workflow',
+            task_list: 'default-test-task-list',
+            input: [42, { arg_1: 1, arg_2: 2 }],
+            task_timeout: Cadence.configuration.timeouts[:task],
+            execution_timeout: Cadence.configuration.timeouts[:execution],
+            workflow_id_reuse_policy: nil,
+            headers: {}
+          )
+      end
+
+      it 'starts a workflow using specified workflow_id' do
+        subject.start_workflow(TestStartWorkflow, 42, options: { workflow_id: '123' })
+
+        expect(connection)
+          .to have_received(:start_workflow_execution)
+          .with(
+            domain: 'default-test-domain',
+            workflow_id: '123',
+            workflow_name: 'TestStartWorkflow',
+            task_list: 'default-test-task-list',
+            input: [42],
+            task_timeout: Cadence.configuration.timeouts[:task],
+            execution_timeout: Cadence.configuration.timeouts[:execution],
+            workflow_id_reuse_policy: nil,
+            headers: {}
+          )
+      end
+
+      it 'starts a workflow with a workflow id reuse policy' do
+        subject.start_workflow(
+          TestStartWorkflow, 42, options: { workflow_id_reuse_policy: :allow }
+        )
+
+        expect(connection)
+          .to have_received(:start_workflow_execution)
+          .with(
+            domain: 'default-test-domain',
+            workflow_id: an_instance_of(String),
+            workflow_name: 'TestStartWorkflow',
+            task_list: 'default-test-task-list',
+            input: [42],
+            task_timeout: Cadence.configuration.timeouts[:task],
+            execution_timeout: Cadence.configuration.timeouts[:execution],
+            workflow_id_reuse_policy: :allow,
+            headers: {}
+          )
+      end
+    end
+
+    context 'using a string reference' do
+      it 'starts a workflow' do
+        subject.start_workflow(
+          'test-workflow',
+          42,
+          options: { domain: 'test-domain', task_list: 'test-task-list' }
+        )
+
+        expect(connection)
+          .to have_received(:start_workflow_execution)
+          .with(
+            domain: 'test-domain',
+            workflow_id: an_instance_of(String),
+            workflow_name: 'test-workflow',
+            task_list: 'test-task-list',
+            input: [42],
+            task_timeout: Cadence.configuration.timeouts[:task],
+            execution_timeout: Cadence.configuration.timeouts[:execution],
+            workflow_id_reuse_policy: nil,
+            headers: {}
+          )
+      end
+    end
+  end
+
+  describe '#register_domain' do
+    before { allow(connection).to receive(:register_domain).and_return(nil) }
+
+    it 'registers domain with the specified name' do
+      subject.register_domain('new-domain')
+
+      expect(connection)
+        .to have_received(:register_domain)
+        .with(name: 'new-domain', description: nil)
+    end
+
+    it 'registers domain with the specified name and description' do
+      subject.register_domain('new-domain', 'domain description')
+
+      expect(connection)
+        .to have_received(:register_domain)
+        .with(name: 'new-domain', description: 'domain description')
+    end
+
+    context 'when domain is already registered' do
+      before do
+        allow(connection)
+          .to receive(:register_domain)
+          .and_raise(CadenceThrift::DomainAlreadyExistsError)
+      end
+
+      it 'does not raise error' do
+        expect do
+          subject.register_domain('new-domain', 'domain description')
+        end.not_to raise_error
+      end
+    end
+  end
+
+  describe '#terminate_workflow' do
+    before { allow(connection).to receive(:terminate_workflow_execution).and_return(nil) }
+
+    it 'terminates workflow execution' do
+      subject.terminate_workflow('test-domain', 'xxx', 'yyy')
+
+      expect(connection)
+        .to have_received(:terminate_workflow_execution)
+        .with(
+          domain: 'test-domain',
+          workflow_id: 'xxx',
+          run_id: 'yyy',
+          reason: 'manual termination',
+          details: nil
+        )
+    end
+
+    it 'terminates workflow execution with extra details' do
+      subject.terminate_workflow(
+        'test-domain',
+        'xxx',
+        'yyy',
+        reason: 'test reason',
+        details: '{ "foo": "bar" }'
+      )
+
+      expect(connection)
+        .to have_received(:terminate_workflow_execution)
+        .with(
+          domain: 'test-domain',
+          workflow_id: 'xxx',
+          run_id: 'yyy',
+          reason: 'test reason',
+          details: '{ "foo": "bar" }'
+        )
+    end
+  end
+
+  describe '#fetch_workflow_execution_info' do
+    let(:response) do
+      instance_double(
+        CadenceThrift::DescribeWorkflowExecutionResponse,
+        workflowExecutionInfo: info_thrift
+      )
+    end
+    let(:info_thrift) { Fabricate(:workflow_execution_info_thrift) }
+
+    before { allow(connection).to receive(:describe_workflow_execution).and_return(response) }
+
+    it 'requests execution info from Cadence' do
+      subject.fetch_workflow_execution_info('domain', '111', '222')
+
+      expect(connection)
+        .to have_received(:describe_workflow_execution)
+        .with(domain: 'domain', workflow_id: '111', run_id: '222')
+    end
+
+    it 'returns Workflow::ExecutionInfo' do
+      info = subject.fetch_workflow_execution_info('domain', '111', '222')
+
+      expect(info).to be_a(Cadence::Workflow::ExecutionInfo)
+    end
+  end
+
+  describe '#get_workflow_history' do
+    let(:response_mock) { double }
+    let(:history_mock) { double}
+    let(:event_mock) { double('EventMock', eventId: 1, timestamp: Time.now.to_f, eventType: 'ActivityTaskStarted', eventAttributes: '') }
+
+    before do
+      allow(history_mock).to receive(:events).and_return([event_mock])
+      allow(response_mock).to receive(:history).and_return(history_mock)
+      allow(connection).to receive(:get_workflow_execution_history).and_return(response_mock)
+    end
+
+    it 'wraps connection get_workflow_execution_history' do
+        subject.get_workflow_history(
+          domain:'default-test-domain',
+          workflow_id: '123',
+          run_id: '1234'
+        )
+        expect(connection).to have_received(:get_workflow_execution_history).with(
+          domain: 'default-test-domain',
+          workflow_id: '123',
+          run_id: '1234'
+        )
+    end
+  end
+
+  describe '#reset_workflow' do
+    let(:cadence_response) { CadenceThrift::StartWorkflowExecutionResponse.new(runId: 'xxx') }
+
+    before { allow(connection).to receive(:reset_workflow_execution).and_return(cadence_response) }
+
+    context 'when decision_task_id is provided' do
+      let(:decision_task_id) { 42 }
+
+      it 'calls connection reset_workflow_execution' do
+        subject.reset_workflow(
+          'default-test-domain',
+          '123',
+          '1234',
+          decision_task_id: decision_task_id,
+          reason: 'Test reset'
+        )
+
+        expect(connection).to have_received(:reset_workflow_execution).with(
+          domain: 'default-test-domain',
+          workflow_id: '123',
+          run_id: '1234',
+          reason: 'Test reset',
+          decision_task_event_id: decision_task_id
+        )
+      end
+
+      it 'returns the new run_id' do
+        result = subject.reset_workflow(
+          'default-test-domain',
+          '123',
+          '1234',
+          decision_task_id: decision_task_id
+        )
+
+        expect(result).to eq('xxx')
+      end
+    end
+  end
+
+  describe 'async activity operations' do
+    let(:domain) { 'test-domain' }
+    let(:activity_id) { rand(100).to_s }
+    let(:workflow_id) { SecureRandom.uuid }
+    let(:run_id) { SecureRandom.uuid }
+    let(:async_token) do
+      Cadence::Activity::AsyncToken.encode(domain, activity_id, workflow_id, run_id)
+    end
+
+    describe '#complete_activity' do
+      before { allow(connection).to receive(:respond_activity_task_completed_by_id).and_return(nil) }
+
+      it 'completes activity with a result' do
+        subject.complete_activity(async_token, 'all work completed')
+
+        expect(connection)
+          .to have_received(:respond_activity_task_completed_by_id)
+          .with(
+            domain: domain,
+            activity_id: activity_id,
+            workflow_id: workflow_id,
+            run_id: run_id,
+            result: 'all work completed'
+          )
+      end
+
+      it 'completes activity without a result' do
+        subject.complete_activity(async_token)
+
+        expect(connection)
+          .to have_received(:respond_activity_task_completed_by_id)
+          .with(
+            domain: domain,
+            activity_id: activity_id,
+            workflow_id: workflow_id,
+            run_id: run_id,
+            result: nil
+          )
+      end
+    end
+
+    describe '#fail_activity' do
+      before { allow(connection).to receive(:respond_activity_task_failed_by_id).and_return(nil) }
+
+      it 'fails activity with a provided error' do
+        subject.fail_activity(async_token, StandardError.new('something went wrong'))
+
+        expect(connection)
+          .to have_received(:respond_activity_task_failed_by_id)
+          .with(
+            domain: domain,
+            activity_id: activity_id,
+            workflow_id: workflow_id,
+            run_id: run_id,
+            reason: 'StandardError',
+            details: 'something went wrong'
+          )
+      end
+    end
+  end
+end

--- a/spec/unit/lib/cadence_spec.rb
+++ b/spec/unit/lib/cadence_spec.rb
@@ -1,417 +1,61 @@
 require 'cadence'
-require 'cadence/workflow'
-require 'cadence/connection/thrift'
 
 describe Cadence do
-  describe 'client operations' do
-    let(:connection) { instance_double(Cadence::Connection::Thrift) }
+  describe 'public method forwarding' do
+    let(:client) { instance_double(Cadence::Client) }
 
-    before { allow(Cadence::Connection).to receive(:generate).and_return(connection) }
-    after { described_class.remove_instance_variable(:@connection) }
+    before { allow(Cadence::Client).to receive(:new).and_return(client) }
+    after { described_class.remove_instance_variable(:@default_client) }
+
+    shared_examples 'a forwarded method' do |method, *args, **kwargs|
+      it 'forwards mehod call to the default client instance' do
+        allow(client).to receive(method)
+
+        described_class.public_send(method, *args, **kwargs)
+
+        expect(client).to have_received(method).with(*args, **kwargs)
+      end
+    end
 
     describe '.start_workflow' do
-      let(:cadence_response) do
-        CadenceThrift::StartWorkflowExecutionResponse.new(runId: 'xxx')
-      end
+      it_behaves_like 'a forwarded method', :start_workflow, 'TestWorkflow', 42
+    end
 
-      before { allow(connection).to receive(:start_workflow_execution).and_return(cadence_response) }
-
-      context 'using a workflow class' do
-        class TestStartWorkflow < Cadence::Workflow
-          domain 'default-test-domain'
-          task_list 'default-test-task-list'
-        end
-
-        it 'returns run_id' do
-          result = described_class.start_workflow(TestStartWorkflow, 42)
-
-          expect(result).to eq(cadence_response.runId)
-        end
-
-        it 'starts a workflow using the default options' do
-          described_class.start_workflow(TestStartWorkflow, 42)
-
-          expect(connection)
-            .to have_received(:start_workflow_execution)
-            .with(
-              domain: 'default-test-domain',
-              workflow_id: an_instance_of(String),
-              workflow_name: 'TestStartWorkflow',
-              task_list: 'default-test-task-list',
-              input: [42],
-              task_timeout: Cadence.configuration.timeouts[:task],
-              execution_timeout: Cadence.configuration.timeouts[:execution],
-              workflow_id_reuse_policy: nil,
-              headers: {}
-            )
-        end
-
-        it 'starts a workflow using the options specified' do
-          described_class.start_workflow(
-            TestStartWorkflow,
-            42,
-            options: {
-              name: 'test-workflow',
-              domain: 'test-domain',
-              task_list: 'test-task-list',
-              headers: { 'Foo' => 'Bar' }
-            }
-          )
-
-          expect(connection)
-            .to have_received(:start_workflow_execution)
-            .with(
-              domain: 'test-domain',
-              workflow_id: an_instance_of(String),
-              workflow_name: 'test-workflow',
-              task_list: 'test-task-list',
-              input: [42],
-              task_timeout: Cadence.configuration.timeouts[:task],
-              execution_timeout: Cadence.configuration.timeouts[:execution],
-              workflow_id_reuse_policy: nil,
-              headers: { 'Foo' => 'Bar' }
-            )
-        end
-
-        it 'starts a cron workflow' do
-          described_class.schedule_workflow(
-            TestStartWorkflow,
-            '* * * * *',
-            42,
-            options: {
-              name: 'test-workflow',
-              domain: 'test-domain',
-              task_list: 'test-task-list',
-              headers: { 'Foo' => 'Bar' },
-
-            }
-          )
-
-          expect(connection)
-            .to have_received(:start_workflow_execution)
-            .with(
-              domain: 'test-domain',
-              workflow_id: an_instance_of(String),
-              workflow_name: 'test-workflow',
-              task_list: 'test-task-list',
-              cron_schedule: '* * * * *',
-              input: [42],
-              task_timeout: Cadence.configuration.timeouts[:task],
-              execution_timeout: Cadence.configuration.timeouts[:execution],
-              workflow_id_reuse_policy: nil,
-              headers: { 'Foo' => 'Bar' }
-            )
-        end
-
-        it 'starts a workflow using a mix of input, keyword arguments and options' do
-          described_class.start_workflow(
-            TestStartWorkflow,
-            42,
-            arg_1: 1,
-            arg_2: 2,
-            options: { name: 'test-workflow' }
-          )
-
-          expect(connection)
-            .to have_received(:start_workflow_execution)
-            .with(
-              domain: 'default-test-domain',
-              workflow_id: an_instance_of(String),
-              workflow_name: 'test-workflow',
-              task_list: 'default-test-task-list',
-              input: [42, { arg_1: 1, arg_2: 2 }],
-              task_timeout: Cadence.configuration.timeouts[:task],
-              execution_timeout: Cadence.configuration.timeouts[:execution],
-              workflow_id_reuse_policy: nil,
-              headers: {}
-            )
-        end
-
-        it 'starts a workflow using specified workflow_id' do
-          described_class.start_workflow(TestStartWorkflow, 42, options: { workflow_id: '123' })
-
-          expect(connection)
-            .to have_received(:start_workflow_execution)
-            .with(
-              domain: 'default-test-domain',
-              workflow_id: '123',
-              workflow_name: 'TestStartWorkflow',
-              task_list: 'default-test-task-list',
-              input: [42],
-              task_timeout: Cadence.configuration.timeouts[:task],
-              execution_timeout: Cadence.configuration.timeouts[:execution],
-              workflow_id_reuse_policy: nil,
-              headers: {}
-            )
-        end
-
-        it 'starts a workflow with a workflow id reuse policy' do
-          described_class.start_workflow(
-            TestStartWorkflow, 42, options: { workflow_id_reuse_policy: :allow }
-          )
-
-          expect(connection)
-            .to have_received(:start_workflow_execution)
-            .with(
-              domain: 'default-test-domain',
-              workflow_id: an_instance_of(String),
-              workflow_name: 'TestStartWorkflow',
-              task_list: 'default-test-task-list',
-              input: [42],
-              task_timeout: Cadence.configuration.timeouts[:task],
-              execution_timeout: Cadence.configuration.timeouts[:execution],
-              workflow_id_reuse_policy: :allow,
-              headers: {}
-            )
-        end
-      end
-
-      context 'using a string reference' do
-        it 'starts a workflow' do
-          described_class.start_workflow(
-            'test-workflow',
-            42,
-            options: { domain: 'test-domain', task_list: 'test-task-list' }
-          )
-
-          expect(connection)
-            .to have_received(:start_workflow_execution)
-            .with(
-              domain: 'test-domain',
-              workflow_id: an_instance_of(String),
-              workflow_name: 'test-workflow',
-              task_list: 'test-task-list',
-              input: [42],
-              task_timeout: Cadence.configuration.timeouts[:task],
-              execution_timeout: Cadence.configuration.timeouts[:execution],
-              workflow_id_reuse_policy: nil,
-              headers: {}
-            )
-        end
-      end
+    describe '.schedule_workflow' do
+      it_behaves_like 'a forwarded method', :schedule_workflow, 'TestWorkflow', '* * * * *', 42
     end
 
     describe '.register_domain' do
-      before { allow(connection).to receive(:register_domain).and_return(nil) }
-
-      it 'registers domain with the specified name' do
-        described_class.register_domain('new-domain')
-
-        expect(connection)
-          .to have_received(:register_domain)
-          .with(name: 'new-domain', description: nil)
-      end
-
-      it 'registers domain with the specified name and description' do
-        described_class.register_domain('new-domain', 'domain description')
-
-        expect(connection)
-          .to have_received(:register_domain)
-          .with(name: 'new-domain', description: 'domain description')
-      end
-
-      context 'when domain is already registered' do
-        before do
-          allow(connection)
-            .to receive(:register_domain)
-            .and_raise(CadenceThrift::DomainAlreadyExistsError)
-        end
-
-        it 'does not raise error' do
-          expect do
-            described_class.register_domain('new-domain', 'domain description')
-          end.not_to raise_error
-        end
-      end
+      it_behaves_like 'a forwarded method', :register_domain, 'test-domain', 'This is a test domain'
     end
 
-    describe '.terminate_workflow' do
-      before { allow(connection).to receive(:terminate_workflow_execution).and_return(nil) }
-
-      it 'terminates workflow execution' do
-        described_class.terminate_workflow('test-domain', 'xxx', 'yyy')
-
-        expect(connection)
-          .to have_received(:terminate_workflow_execution)
-          .with(
-            domain: 'test-domain',
-            workflow_id: 'xxx',
-            run_id: 'yyy',
-            reason: 'manual termination',
-            details: nil
-          )
-      end
-
-      it 'terminates workflow execution with extra details' do
-        described_class.terminate_workflow(
-          'test-domain',
-          'xxx',
-          'yyy',
-          reason: 'test reason',
-          details: '{ "foo": "bar" }'
-        )
-
-        expect(connection)
-          .to have_received(:terminate_workflow_execution)
-          .with(
-            domain: 'test-domain',
-            workflow_id: 'xxx',
-            run_id: 'yyy',
-            reason: 'test reason',
-            details: '{ "foo": "bar" }'
-          )
-      end
-    end
-
-    describe '.fetch_workflow_execution_info' do
-      let(:response) do
-        instance_double(
-          CadenceThrift::DescribeWorkflowExecutionResponse,
-          workflowExecutionInfo: info_thrift
-        )
-      end
-      let(:info_thrift) { Fabricate(:workflow_execution_info_thrift) }
-
-      before { allow(connection).to receive(:describe_workflow_execution).and_return(response) }
-
-      it 'requests execution info from Cadence' do
-        described_class.fetch_workflow_execution_info('domain', '111', '222')
-
-        expect(connection)
-          .to have_received(:describe_workflow_execution)
-          .with(domain: 'domain', workflow_id: '111', run_id: '222')
-      end
-
-      it 'returns Workflow::ExecutionInfo' do
-        info = described_class.fetch_workflow_execution_info('domain', '111', '222')
-
-        expect(info).to be_a(Cadence::Workflow::ExecutionInfo)
-      end
-    end
-
-    describe '.get_workflow_history' do
-      let(:response_mock) { double }
-      let(:history_mock) { double}
-      let(:event_mock) { double('EventMock', eventId: 1, timestamp: Time.now.to_f, eventType: 'ActivityTaskStarted', eventAttributes: '') }
-
-      before do
-        allow(history_mock).to receive(:events).and_return([event_mock])
-        allow(response_mock).to receive(:history).and_return(history_mock)
-        allow(connection).to receive(:get_workflow_execution_history).and_return(response_mock)
-      end
-
-      it 'wraps connection get_workflow_execution_history' do
-          described_class.get_workflow_history(
-            domain:'default-test-domain',
-            workflow_id: '123',
-            run_id: '1234'
-          )
-          expect(connection).to have_received(:get_workflow_execution_history).with(
-            domain: 'default-test-domain',
-            workflow_id: '123',
-            run_id: '1234'
-          )
-      end
+    describe '.signal_workflow' do
+      it_behaves_like 'a forwarded method', :signal_workflow, 'TestWorkflow', 'TST_SIGNAL', 'x', 'y'
     end
 
     describe '.reset_workflow' do
-      let(:cadence_response) { CadenceThrift::StartWorkflowExecutionResponse.new(runId: 'xxx') }
-
-      before { allow(connection).to receive(:reset_workflow_execution).and_return(cadence_response) }
-
-      context 'when decision_task_id is provided' do
-        let(:decision_task_id) { 42 }
-
-        it 'calls connection reset_workflow_execution' do
-          described_class.reset_workflow(
-            'default-test-domain',
-            '123',
-            '1234',
-            decision_task_id: decision_task_id,
-            reason: 'Test reset'
-          )
-
-          expect(connection).to have_received(:reset_workflow_execution).with(
-            domain: 'default-test-domain',
-            workflow_id: '123',
-            run_id: '1234',
-            reason: 'Test reset',
-            decision_task_event_id: decision_task_id
-          )
-        end
-
-        it 'returns the new run_id' do
-          result = described_class.reset_workflow(
-            'default-test-domain',
-            '123',
-            '1234',
-            decision_task_id: decision_task_id
-          )
-
-          expect(result).to eq('xxx')
-        end
-      end
+      it_behaves_like 'a forwarded method', :reset_workflow, 'test-domain', 'x', 'y'
     end
 
-    context 'activity operations' do
-      let(:domain) { 'test-domain' }
-      let(:activity_id) { rand(100).to_s }
-      let(:workflow_id) { SecureRandom.uuid }
-      let(:run_id) { SecureRandom.uuid }
-      let(:async_token) do
-        Cadence::Activity::AsyncToken.encode(domain, activity_id, workflow_id, run_id)
-      end
+    describe '.terminate_workflow' do
+      it_behaves_like 'a forwarded method', :terminate_workflow, 'test-domain', 'x', 'y'
+    end
 
-      describe '.complete_activity' do
-        before { allow(connection).to receive(:respond_activity_task_completed_by_id).and_return(nil) }
+    describe '.fetch_workflow_execution_info' do
+      it_behaves_like 'a forwarded method', :fetch_workflow_execution_info, 'test-domain', 'x', 'y'
+    end
 
-        it 'completes activity with a result' do
-          described_class.complete_activity(async_token, 'all work completed')
+    describe '.complete_activity' do
+      it_behaves_like 'a forwarded method', :complete_activity, 'test-token', 'result'
+    end
 
-          expect(connection)
-            .to have_received(:respond_activity_task_completed_by_id)
-            .with(
-              domain: domain,
-              activity_id: activity_id,
-              workflow_id: workflow_id,
-              run_id: run_id,
-              result: 'all work completed'
-            )
-        end
+    describe '.fail_activity' do
+      it_behaves_like 'a forwarded method', :complete_activity, 'test-token', StandardError.new
+    end
 
-        it 'completes activity without a result' do
-          described_class.complete_activity(async_token)
-
-          expect(connection)
-            .to have_received(:respond_activity_task_completed_by_id)
-            .with(
-              domain: domain,
-              activity_id: activity_id,
-              workflow_id: workflow_id,
-              run_id: run_id,
-              result: nil
-            )
-        end
-      end
-
-      describe '.fail_activity' do
-        before { allow(connection).to receive(:respond_activity_task_failed_by_id).and_return(nil) }
-
-        it 'fails activity with a provided error' do
-          described_class.fail_activity(async_token, StandardError.new('something went wrong'))
-
-          expect(connection)
-            .to have_received(:respond_activity_task_failed_by_id)
-            .with(
-              domain: domain,
-              activity_id: activity_id,
-              workflow_id: workflow_id,
-              run_id: run_id,
-              reason: 'StandardError',
-              details: 'something went wrong'
-            )
-        end
-      end
+    describe '.get_workflow_history' do
+      it_behaves_like 'a forwarded method',
+        :get_workflow_history, domain: 'test-domain', workflow_id: 'x', run_id: 'y'
     end
   end
 
@@ -432,6 +76,12 @@ describe Cadence do
   describe '.logger' do
     it 'returns preconfigured Cadence logger' do
       expect(described_class.logger).to eq(described_class.configuration.logger)
+    end
+  end
+
+  describe '.metrics' do
+    it 'returns preconfigured Cadence metrics' do
+      expect(described_class.metrics).to an_instance_of(Cadence::Metrics)
     end
   end
 end

--- a/spec/unit/lib/cadence_spec.rb
+++ b/spec/unit/lib/cadence_spec.rb
@@ -7,13 +7,13 @@ describe Cadence do
     before { allow(Cadence::Client).to receive(:new).and_return(client) }
     after { described_class.remove_instance_variable(:@default_client) }
 
-    shared_examples 'a forwarded method' do |method, *args, **kwargs|
+    shared_examples 'a forwarded method' do |method, *args, kwargs|
       it 'forwards mehod call to the default client instance' do
         allow(client).to receive(method)
 
-        described_class.public_send(method, *args, **kwargs)
+        described_class.public_send(method, *args, kwargs)
 
-        expect(client).to have_received(method).with(*args, **kwargs)
+        expect(client).to have_received(method).with(*args, kwargs)
       end
     end
 


### PR DESCRIPTION
This turns `Cadence` into an initializable `Cadence::Client` allowing to connect to multiple clusters:

```
config_1 = Cadence::Configuration.new
config_1.host = 'xxx'

client_1 = Cadence::Client.new(config_1)
client_1.start_workflow(TestWorkflow)

config_2 = Cadence::Configuration.new
config_2.host = 'xxx'

client_2 = Cadence::Client.new(config_2)
client_2.start_workflow(TestWorkflow)
```

This change is backwards compatible and `Cadence.*` class methods are simply delegated to a default client.

The "meat" of this PR is moving `Cadence` methods into `Cadence::Client` and moving specs