### PR TITLE
Fix documentation spelling and broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Odin
+# Contributing to Cadence-Ruby
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Besides calling activities workflows can:
 
 - Use timers
 - Receive signals
-- Execute other (child) workflows [not yet implemented]
+- Execute other (child) workflows
 - Respond to queries [not yet implemented]
 
 
@@ -433,7 +433,7 @@ Cadence::Testing.local! do
 end
 ```
 
-Make sure to check out [example integration specs](examples/specs/integration) for more details.
+Make sure to check out [example integration specs](examples/spec/integration) for more details.
 
 
 ## TODO

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Ruby Cadence Examples
 
-This directory contains examples demonstraiting different features or this library and Cadence.
+This directory contains examples demonstrating different features of this library and Cadence.
 
 To try these out you need to have Cadence and TChannel Proxy running ([setup instructions](https://github.com/coinbase/cadence-ruby#installing-dependencies)).
 

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -1,6 +1,6 @@
 # Cadence Proxy
 
-A small executable that accepts incomming Thrift/HTTP requests and proxies them to Cadence server
+A small executable that accepts incoming Thrift/HTTP requests and proxies them to Cadence server
 using Thrift/TChannel.
 
 ## Why?


### PR DESCRIPTION
This fixes a couple spelling mistakes and a broken link.  It also removes the [not yet implemented] note for child workflows from the README as it looks like they were implemented with #7 . 