### PR TITLE
[Feature] Make retry_policy mergeable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.4
+- Fix a bug which prevented retry_policy from being passed as explicit options
+- Make retry_policy options mergeable with the values in an Activity or a Workflow
+
 ## 0.1.3
 - Expose Cadence::Activity::AsyncToken in RBI
 

--- a/lib/cadence/concerns/executable.rb
+++ b/lib/cadence/concerns/executable.rb
@@ -1,5 +1,3 @@
-require 'cadence/retry_policy'
-
 module Cadence
   module Concerns
     module Executable
@@ -15,8 +13,7 @@ module Cadence
 
       def retry_policy(*args)
         return @retry_policy if args.empty?
-        @retry_policy = Cadence::RetryPolicy.new(args.first)
-        @retry_policy.validate!
+        @retry_policy = args.first
       end
 
       def timeouts(*args)

--- a/lib/cadence/execution_options.rb
+++ b/lib/cadence/execution_options.rb
@@ -1,31 +1,42 @@
 require 'cadence/concerns/executable'
+require 'cadence/retry_policy'
 
 module Cadence
   class ExecutionOptions
     attr_reader :name, :domain, :task_list, :retry_policy, :timeouts, :headers
 
     def initialize(object, options, defaults = nil)
+      # Options are treated as overrides and take precedence
       @name = options[:name] || object.to_s
       @domain = options[:domain]
       @task_list = options[:task_list]
-      @retry_policy = options[:retry_policy]
+      @retry_policy = options[:retry_policy] || {}
       @cron_schedule = options[:cron_schedule]
       @timeouts = options[:timeouts] || {}
       @headers = options[:headers] || {}
 
+      # For Cadence::Workflow and Cadence::Activity use defined values as the next option
       if object.singleton_class.included_modules.include?(Concerns::Executable)
         @domain ||= object.domain
         @task_list ||= object.task_list
-        @retry_policy ||= object.retry_policy
+        @retry_policy = object.retry_policy.merge(@retry_policy) if object.retry_policy
         @timeouts = object.timeouts.merge(@timeouts) if object.timeouts
         @headers = object.headers.merge(@headers) if object.headers
       end
 
+      # Lastly consider defaults if they are given
       if defaults
         @domain ||= defaults.domain
         @task_list ||= defaults.task_list
         @timeouts = defaults.timeouts.merge(@timeouts)
         @headers = defaults.headers.merge(@headers)
+      end
+
+      if @retry_policy.empty?
+        @retry_policy = nil
+      else
+        @retry_policy = Cadence::RetryPolicy.new(@retry_policy)
+        @retry_policy.validate!
       end
 
       freeze

--- a/lib/cadence/version.rb
+++ b/lib/cadence/version.rb
@@ -1,3 +1,3 @@
 module Cadence
-  VERSION = '0.1.3'.freeze
+  VERSION = '0.1.4'.freeze
 end

--- a/spec/shared_examples/an_executable.rb
+++ b/spec/shared_examples/an_executable.rb
@@ -35,24 +35,15 @@ shared_examples 'an executable' do
     after { described_class.remove_instance_variable(:@retry_policy) }
 
     it 'gets current retry policy' do
-      retry_policy = Cadence::RetryPolicy.new
-      described_class.instance_variable_set(:@retry_policy, retry_policy)
+      described_class.instance_variable_set(:@retry_policy, :test)
 
-      expect(described_class.retry_policy).to eq(retry_policy)
+      expect(described_class.retry_policy).to eq(:test)
     end
 
     it 'sets new valid retry policy' do
-      policy = { interval: 1, backoff: 1, max_attempts: 3 }
-      described_class.retry_policy(policy)
+      described_class.retry_policy(:test)
 
-      expect(described_class.instance_variable_get(:@retry_policy))
-        .to eq(Cadence::RetryPolicy.new(policy))
-    end
-
-    it 'raises when setting invalid retry policy' do
-      expect do
-        described_class.retry_policy(interval: 0.1)
-      end.to raise_error(Cadence::RetryPolicy::InvalidRetryPolicy)
+      expect(described_class.instance_variable_get(:@retry_policy)).to eq(:test)
     end
   end
 

--- a/spec/unit/lib/cadence/execution_options_spec.rb
+++ b/spec/unit/lib/cadence/execution_options_spec.rb
@@ -1,0 +1,198 @@
+require 'cadence/execution_options'
+require 'cadence/configuration'
+
+describe Cadence::ExecutionOptions do
+  subject { described_class.new(object, options, defaults) }
+  let(:defaults) { nil }
+  let(:options) { { domain: 'test-domain', task_list: 'test-task-list' } }
+
+  context 'when initialized with a String' do
+    let(:object) { 'TestWorkflow' }
+
+    it 'is initialized with object as the name' do
+      expect(subject.name).to eq(object)
+      expect(subject.domain).to eq(options[:domain])
+      expect(subject.task_list).to eq(options[:task_list])
+      expect(subject.retry_policy).to be_nil
+      expect(subject.timeouts).to eq({})
+      expect(subject.headers).to eq({})
+    end
+
+    context 'when options include :name' do
+      let(:options) do
+        { name: 'OtherTestWorkflow', domain: 'test-domain', task_list: 'test-task-list' }
+      end
+
+      it 'is initialized with name from options' do
+        expect(subject.name).to eq(options[:name])
+        expect(subject.domain).to eq(options[:domain])
+        expect(subject.task_list).to eq(options[:task_list])
+        expect(subject.retry_policy).to be_nil
+        expect(subject.timeouts).to eq({})
+        expect(subject.headers).to eq({})
+      end
+    end
+
+    context 'with defaults given' do
+      let(:options) do
+        {
+          domain: 'test-domain',
+          timeouts: { start_to_close: 10 },
+          headers: { 'TestHeader' => 'Test' }
+        }
+      end
+      let(:defaults) do
+        Cadence::Configuration::Execution.new(
+          domain: 'default-domain',
+          task_list: 'default-task-list',
+          timeouts: { schedule_to_close: 42 },
+          headers: { 'DefaultHeader' => 'Default' }
+        )
+      end
+
+      it 'is initialized with a mix of options and defaults' do
+        expect(subject.name).to eq(object)
+        expect(subject.domain).to eq(options[:domain])
+        expect(subject.task_list).to eq(defaults.task_list)
+        expect(subject.retry_policy).to be_nil
+        expect(subject.timeouts).to eq(schedule_to_close: 42, start_to_close: 10)
+        expect(subject.headers).to eq('DefaultHeader' => 'Default', 'TestHeader' => 'Test')
+      end
+    end
+
+    context 'with full options' do
+      let(:options) do
+        {
+          name: 'OtherTestWorkflow',
+          domain: 'test-domain',
+          task_list: 'test-task-list',
+          retry_policy: { interval: 1, backoff: 2, max_attempts: 5 },
+          timeouts: { start_to_close: 10 },
+          headers: { 'TestHeader' => 'Test' }
+        }
+      end
+
+      it 'is initialized with full options' do
+        expect(subject.name).to eq(options[:name])
+        expect(subject.domain).to eq(options[:domain])
+        expect(subject.task_list).to eq(options[:task_list])
+        expect(subject.retry_policy).to be_an_instance_of(Cadence::RetryPolicy)
+        expect(subject.retry_policy.interval).to eq(options[:retry_policy][:interval])
+        expect(subject.retry_policy.backoff).to eq(options[:retry_policy][:backoff])
+        expect(subject.retry_policy.max_attempts).to eq(options[:retry_policy][:max_attempts])
+        expect(subject.timeouts).to eq(options[:timeouts])
+        expect(subject.headers).to eq(options[:headers])
+      end
+    end
+
+    context 'when retry policy options are invalid' do
+      let(:options) { { retry_policy: { max_attempts: 10 } } }
+
+      it 'raises' do
+        expect { subject }.to raise_error(
+          Cadence::RetryPolicy::InvalidRetryPolicy,
+          'interval and backoff must be set'
+        )
+      end
+    end
+  end
+
+  context 'when initialized with an Executable' do
+    class TestWorkflow < Cadence::Workflow
+      domain 'domain'
+      task_list 'task-list'
+      retry_policy interval: 1, backoff: 2, max_attempts: 5
+      timeouts start_to_close: 10
+      headers 'HeaderA' => 'TestA', 'HeaderB' => 'TestB'
+    end
+
+    let(:object) { TestWorkflow }
+    let(:options) { {} }
+
+    it 'is initialized with executable values' do
+      expect(subject.name).to eq(object.name)
+      expect(subject.domain).to eq('domain')
+      expect(subject.task_list).to eq('task-list')
+      expect(subject.retry_policy).to be_an_instance_of(Cadence::RetryPolicy)
+      expect(subject.retry_policy.interval).to eq(1)
+      expect(subject.retry_policy.backoff).to eq(2)
+      expect(subject.retry_policy.max_attempts).to eq(5)
+      expect(subject.timeouts).to eq(start_to_close: 10)
+      expect(subject.headers).to eq('HeaderA' => 'TestA', 'HeaderB' => 'TestB')
+    end
+
+    context 'when options are present' do
+      let(:options) do
+        {
+          name: 'OtherTestWorkflow',
+          task_list: 'test-task-list',
+          retry_policy: { interval: 2, max_attempts: 10 },
+          timeouts: { schedule_to_close: 20 },
+          headers: { 'TestHeader' => 'Value', 'HeaderB' => 'ValueB' }
+        }
+      end
+
+      it 'is initialized with a mix of options and executable values' do
+        expect(subject.name).to eq(options[:name])
+        expect(subject.domain).to eq('domain')
+        expect(subject.task_list).to eq(options[:task_list])
+        expect(subject.retry_policy).to be_an_instance_of(Cadence::RetryPolicy)
+        expect(subject.retry_policy.interval).to eq(2)
+        expect(subject.retry_policy.backoff).to eq(2)
+        expect(subject.retry_policy.max_attempts).to eq(10)
+        expect(subject.timeouts).to eq(schedule_to_close: 20, start_to_close: 10)
+        expect(subject.headers).to eq(
+          'TestHeader' => 'Value',
+          'HeaderA' => 'TestA',
+          'HeaderB' => 'ValueB' # overriden by options
+        )
+      end
+    end
+
+    context 'with defaults given' do
+      let(:options) do
+        {
+          domain: 'test-domain',
+          timeouts: { schedule_to_start: 10 },
+          headers: { 'TestHeader' => 'Test' }
+        }
+      end
+      let(:defaults) do
+        Cadence::Configuration::Execution.new(
+          domain: 'default-domain',
+          task_list: 'default-task-list',
+          timeouts: { schedule_to_close: 42 },
+          headers: { 'DefaultHeader' => 'Default', 'HeaderA' => 'DefaultA' }
+        )
+      end
+
+      it 'is initialized with a mix of executable values, options and defaults' do
+        expect(subject.name).to eq(object.name)
+        expect(subject.domain).to eq(options[:domain])
+        expect(subject.task_list).to eq('task-list')
+        expect(subject.retry_policy).to be_an_instance_of(Cadence::RetryPolicy)
+        expect(subject.retry_policy.interval).to eq(1)
+        expect(subject.retry_policy.backoff).to eq(2)
+        expect(subject.retry_policy.max_attempts).to eq(5)
+        expect(subject.timeouts).to eq(schedule_to_close: 42, start_to_close: 10, schedule_to_start: 10)
+        expect(subject.headers).to eq(
+          'TestHeader' => 'Test',
+          'HeaderA' => 'TestA',
+          'HeaderB' => 'TestB', # not overriden by defaults
+          'DefaultHeader' => 'Default'
+        )
+      end
+    end
+
+    context 'when retry policy options are invalid' do
+      let(:options) { { retry_policy: { interval: 1.5 } } }
+
+      it 'raises' do
+        expect { subject }.to raise_error(
+          Cadence::RetryPolicy::InvalidRetryPolicy,
+          'All intervals must be specified in whole seconds'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR will make retry_policy passed via options mergeable with the retry_policy specified in the Executable class:

```ruby
class TestActivity < Cadence::Activity
  class TestError < StandardError; end

  retry_policy interval: 1, backoff: 2, max_attempt: 10, non_retriable_errors: [TestError]
end
```

then in a workflow:

```ruby
TestActivity.execute!(options: { retry_policy: { interval: 2, backoff: 3 } })
```

This will partially override activity's retry policy with the explicitly passed options, resulting in `interval: 2, backoff: 3, max_attempt: 10, non_retriable_errors: [TestError]`.

It also fixes a bug with retry_policy passed as options, which didn't work previously. The full set of specs for the ExecutionOptions has been added.