### PR TITLE
[Feature] Strategies for resetting workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.5
+- Implement strategies for resetting workflows
+
 ## 0.1.4
 - Fix a bug which prevented retry_policy from being passed as explicit options
 - Make retry_policy options mergeable with the values in an Activity or a Workflow

--- a/lib/cadence/reset_strategy.rb
+++ b/lib/cadence/reset_strategy.rb
@@ -1,0 +1,7 @@
+module Cadence
+  module ResetStrategy
+    LAST_DECISION_TASK = :last_decision_task
+    FIRST_DECISION_TASK = :first_decision_task
+    LAST_FAILED_ACTIVITY = :last_failed_activity
+  end
+end

--- a/lib/cadence/version.rb
+++ b/lib/cadence/version.rb
@@ -1,3 +1,3 @@
 module Cadence
-  VERSION = '0.1.4'.freeze
+  VERSION = '0.1.5'.freeze
 end

--- a/lib/cadence/workflow/history.rb
+++ b/lib/cadence/workflow/history.rb
@@ -11,8 +11,8 @@ module Cadence
         @iterator = @events.each
       end
 
-      def last_completed_decision_task
-        events.select { |event| event.type == 'DecisionTaskCompleted' }.last
+      def find_event_by_id(id)
+        events.find { |event| event.id == id }
       end
 
       # It is very important to replay the History window by window in order to

--- a/spec/fabricators/thrift/history_event_fabricator.rb
+++ b/spec/fabricators/thrift/history_event_fabricator.rb
@@ -68,3 +68,52 @@ Fabricator(:decision_task_completed_event_thrift, from: :history_event_thrift) d
     )
   end
 end
+
+Fabricator(:activity_task_scheduled_event_thrift, from: :history_event_thrift) do
+  eventType { CadenceThrift::EventType::ActivityTaskScheduled }
+  activityTaskScheduledEventAttributes do |attrs|
+    CadenceThrift::ActivityTaskScheduledEventAttributes.new(
+      activityId: attrs[:eventId],
+      activityType: CadenceThrift::ActivityType.new(name: 'TestActivity'),
+      decisionTaskCompletedEventId: attrs[:eventId] - 1,
+      domain: 'test-domain',
+      taskList: Fabricate(:task_list_thrift)
+    )
+  end
+end
+
+Fabricator(:activity_task_started_event_thrift, from: :history_event_thrift) do
+  eventType { CadenceThrift::EventType::ActivityTaskStarted }
+  activityTaskStartedEventAttributes do |attrs|
+    CadenceThrift::ActivityTaskStartedEventAttributes.new(
+      scheduledEventId: attrs[:eventId] - 1,
+      identity: 'test-worker@test-host',
+      requestId: SecureRandom.uuid
+    )
+  end
+end
+
+Fabricator(:activity_task_completed_event_thrift, from: :history_event_thrift) do
+  eventType { CadenceThrift::EventType::ActivityTaskCompleted }
+  activityTaskCompletedEventAttributes do |attrs|
+    CadenceThrift::ActivityTaskCompletedEventAttributes.new(
+      result: nil,
+      scheduledEventId: attrs[:eventId] - 2,
+      startedEventId: attrs[:eventId] - 1,
+      identity: 'test-worker@test-host'
+    )
+  end
+end
+
+Fabricator(:activity_task_failed_event_thrift, from: :history_event_thrift) do
+  eventType { CadenceThrift::EventType::ActivityTaskFailed }
+  activityTaskFailedEventAttributes do |attrs|
+    CadenceThrift::ActivityTaskFailedEventAttributes.new(
+      reason: 'StandardError',
+      details: 'Activity failed',
+      scheduledEventId: attrs[:eventId] - 2,
+      startedEventId: attrs[:eventId] - 1,
+      identity: 'test-worker@test-host'
+    )
+  end
+end

--- a/spec/unit/lib/cadence/workflow/history_spec.rb
+++ b/spec/unit/lib/cadence/workflow/history_spec.rb
@@ -2,31 +2,6 @@ require 'cadence/workflow/history'
 
 describe Cadence::Workflow::History do
   let(:history) { described_class.new(events) }
-  describe '.last_completed_decision_task' do
-    let(:event_mock_1) do
-      double('EventMock', eventId: 1, timestamp: (Time.now - 1000).to_f, eventType: event_type, eventAttributes: '', public_send: '')
-    end
-    let(:event_mock_2) do
-      double('EventMock', eventId: 2, timestamp: Time.now.to_f, eventType: event_type, eventAttributes: '', public_send: '')
-    end
-  
-    context '> 1 completed decision task exists' do
-      let(:event_type) { CadenceThrift::EventType::DecisionTaskCompleted }
-      let(:events) { [event_mock_1, event_mock_2] }
-
-      it 'returns the last completed decision task' do
-        expect(history.last_completed_decision_task.id).to be(2)
-      end
-    end
-
-    context '0 completed decision task exists' do
-      let(:event_type) { CadenceThrift::EventType::DecisionTaskScheduled }
-      let(:events) { [event_mock_1] }
-      it 'returns nil' do
-        expect(history.last_completed_decision_task).to be(nil)
-      end
-    end
-  end
 
   describe '#next_window' do
   end


### PR DESCRIPTION
This change would allow specifying a strategy when resetting a workflow. This is very useful when resetting a batch of workflows that all might have failed at different points in history

Tested against a running server & specs updated to reflect the change