### PR TITLE
Add Metadata::Base#to_h

### DIFF
--- a/lib/cadence/metadata/activity.rb
+++ b/lib/cadence/metadata/activity.rb
@@ -23,6 +23,18 @@ module Cadence
       def activity?
         true
       end
+
+      def to_h
+        {
+          domain: domain,
+          workflow_id: workflow_id,
+          workflow_name: workflow_name,
+          workflow_run_id: workflow_run_id,
+          activity_id: id,
+          activity_name: name,
+          attempt: attempt
+        }
+      end
     end
   end
 end

--- a/lib/cadence/metadata/base.rb
+++ b/lib/cadence/metadata/base.rb
@@ -12,6 +12,10 @@ module Cadence
       def workflow?
         false
       end
+
+      def to_h
+        raise NotImplementedError, 'Metadata::Base subclass is expected to have #to_h implemented'
+      end
     end
   end
 end

--- a/lib/cadence/metadata/decision.rb
+++ b/lib/cadence/metadata/decision.rb
@@ -20,6 +20,17 @@ module Cadence
       def decision?
         true
       end
+
+      def to_h
+        {
+          domain: domain,
+          decision_task_id: id,
+          workflow_name: workflow_name,
+          workflow_id: workflow_id,
+          workflow_run_id: workflow_run_id,
+          attempt: attempt
+        }
+      end
     end
   end
 end

--- a/lib/cadence/metadata/workflow.rb
+++ b/lib/cadence/metadata/workflow.rb
@@ -18,6 +18,14 @@ module Cadence
       def workflow?
         true
       end
+
+      def to_h
+        {
+          workflow_name: name,
+          workflow_run_id: run_id,
+          attempt: attempt
+        }
+      end
     end
   end
 end

--- a/spec/unit/lib/cadence/metadata/activity_spec.rb
+++ b/spec/unit/lib/cadence/metadata/activity_spec.rb
@@ -1,10 +1,10 @@
 require 'cadence/metadata/activity'
 
 describe Cadence::Metadata::Activity do
-  describe '#initialize' do
-    subject { described_class.new(args.to_h) }
-    let(:args) { Fabricate(:activity_metadata) }
+  subject { described_class.new(args.to_h) }
+  let(:args) { Fabricate(:activity_metadata) }
 
+  describe '#initialize' do
     it 'sets the attributes' do
       expect(subject.domain).to eq(args.domain)
       expect(subject.id).to eq(args.id)
@@ -22,5 +22,19 @@ describe Cadence::Metadata::Activity do
     it { is_expected.to be_activity }
     it { is_expected.not_to be_decision }
     it { is_expected.not_to be_workflow }
+  end
+
+  describe '#to_h' do
+    it 'returns a hash' do
+      expect(subject.to_h).to eq(
+        attempt: subject.attempt,
+        activity_id: subject.id,
+        activity_name: subject.name,
+        domain: subject.domain,
+        workflow_id: subject.workflow_id,
+        workflow_name: subject.workflow_name,
+        workflow_run_id: subject.workflow_run_id
+      )
+    end
   end
 end

--- a/spec/unit/lib/cadence/metadata/decision_spec.rb
+++ b/spec/unit/lib/cadence/metadata/decision_spec.rb
@@ -1,10 +1,10 @@
 require 'cadence/metadata/decision'
 
 describe Cadence::Metadata::Decision do
-  describe '#initialize' do
-    subject { described_class.new(args.to_h) }
-    let(:args) { Fabricate(:decision_metadata) }
+  subject { described_class.new(args.to_h) }
+  let(:args) { Fabricate(:decision_metadata) }
 
+  describe '#initialize' do
     it 'sets the attributes' do
       expect(subject.domain).to eq(args.domain)
       expect(subject.id).to eq(args.id)
@@ -19,5 +19,18 @@ describe Cadence::Metadata::Decision do
     it { is_expected.not_to be_activity }
     it { is_expected.to be_decision }
     it { is_expected.not_to be_workflow }
+  end
+
+  describe '#to_h' do
+    it 'returns a hash' do
+      expect(subject.to_h).to eq(
+        attempt: subject.attempt,
+        decision_task_id: subject.id,
+        domain: subject.domain,
+        workflow_id: subject.workflow_id,
+        workflow_name: subject.workflow_name,
+        workflow_run_id: subject.workflow_run_id,
+      )
+    end
   end
 end

--- a/spec/unit/lib/cadence/metadata/workflow_spec.rb
+++ b/spec/unit/lib/cadence/metadata/workflow_spec.rb
@@ -1,10 +1,10 @@
 require 'cadence/metadata/workflow'
 
 describe Cadence::Metadata::Workflow do
-  describe '#initialize' do
-    subject { described_class.new(args.to_h) }
-    let(:args) { Fabricate(:workflow_metadata) }
+  subject { described_class.new(args.to_h) }
+  let(:args) { Fabricate(:workflow_metadata) }
 
+  describe '#initialize' do
     it 'sets the attributes' do
       expect(subject.name).to eq(args.name)
       expect(subject.run_id).to eq(args.run_id)
@@ -17,5 +17,15 @@ describe Cadence::Metadata::Workflow do
     it { is_expected.not_to be_activity }
     it { is_expected.not_to be_decision }
     it { is_expected.to be_workflow }
+  end
+
+  describe '#to_h' do
+    it 'returns a hash' do
+      expect(subject.to_h).to eq(
+        attempt: subject.attempt,
+        workflow_name: subject.name,
+        workflow_run_id: subject.run_id
+      )
+    end
   end
 end


### PR DESCRIPTION
Synced from https://github.com/coinbase/temporal-ruby/pull/44

This will allow for uniform metadata logging (added separately)