### PR TITLE
[Fix] Correctly handle timer/activity cancelation events

### DIFF
--- a/lib/cadence/workflow/history/event.rb
+++ b/lib/cadence/workflow/history/event.rb
@@ -45,7 +45,7 @@ module Cadence
         # referred to as a "decision" event. Not related to DecisionTask.
         def decision_id
           case type
-          when 'TimerFired'
+          when 'TimerFired', 'TimerCanceled'
             attributes.startedEventId
           when 'WorkflowExecutionSignaled'
             1 # fixed id for everything related to current workflow

--- a/lib/cadence/workflow/history/event_target.rb
+++ b/lib/cadence/workflow/history/event_target.rb
@@ -17,10 +17,12 @@ module Cadence
         WORKFLOW_TYPE                         = :workflow
         CANCEL_WORKFLOW_REQUEST_TYPE          = :cancel_workflow_request
 
+        # NOTE: The order is important, first prefix match wins (will be a longer match)
         TARGET_TYPES = {
-          'ActivityTask'                           => ACTIVITY_TYPE,
           'ActivityTaskCancel'                     => CANCEL_ACTIVITY_REQUEST_TYPE,
+          'ActivityTask'                           => ACTIVITY_TYPE,
           'RequestCancelActivityTask'              => CANCEL_ACTIVITY_REQUEST_TYPE,
+          'TimerCanceled'                          => CANCEL_TIMER_REQUEST_TYPE,
           'Timer'                                  => TIMER_TYPE,
           'CancelTimer'                            => CANCEL_TIMER_REQUEST_TYPE,
           'ChildWorkflowExecution'                 => CHILD_WORKFLOW_TYPE,
@@ -31,8 +33,8 @@ module Cadence
           'ExternalWorkflowExecutionCancel'        => CANCEL_EXTERNAL_WORKFLOW_REQUEST_TYPE,
           'RequestCancelExternalWorkflowExecution' => CANCEL_EXTERNAL_WORKFLOW_REQUEST_TYPE,
           'UpsertWorkflowSearchAttributes'         => WORKFLOW_TYPE,
-          'WorkflowExecution'                      => WORKFLOW_TYPE,
           'WorkflowExecutionCancel'                => CANCEL_WORKFLOW_REQUEST_TYPE,
+          'WorkflowExecution'                      => WORKFLOW_TYPE,
         }.freeze
 
         attr_reader :id, :type

--- a/lib/cadence/workflow/state_manager.rb
+++ b/lib/cadence/workflow/state_manager.rb
@@ -155,6 +155,7 @@ module Cadence
 
         when 'RequestCancelActivityTaskFailed'
           state_machine.fail
+          discard_decision(target)
           dispatch(target, 'failed', event.attributes.cause, nil)
 
         when 'ActivityTaskCanceled'
@@ -171,10 +172,12 @@ module Cadence
 
         when 'CancelTimerFailed'
           state_machine.failed
+          discard_decision(target)
           dispatch(target, 'failed', event.attributes.cause, nil)
 
         when 'TimerCanceled'
           state_machine.cancel
+          discard_decision(target)
           dispatch(target, 'canceled')
 
         when 'WorkflowExecutionCancelRequested'

--- a/spec/fabricators/thrift/history_event_fabricator.rb
+++ b/spec/fabricators/thrift/history_event_fabricator.rb
@@ -117,3 +117,36 @@ Fabricator(:activity_task_failed_event_thrift, from: :history_event_thrift) do
     )
   end
 end
+
+Fabricator(:timer_started_event_thrift, from: :history_event_thrift) do
+  eventType { CadenceThrift::EventType::TimerStarted }
+  timerStartedEventAttributes do |attrs|
+    CadenceThrift::TimerStartedEventAttributes.new(
+      timerId: attrs[:eventId],
+      startToFireTimeoutSeconds: 10,
+      decisionTaskCompletedEventId: attrs[:eventId] - 1
+    )
+  end
+end
+
+Fabricator(:timer_fired_event_thrift, from: :history_event_thrift) do
+  eventType { CadenceThrift::EventType::TimerFired }
+  timerFiredEventAttributes do |attrs|
+    CadenceThrift::TimerFiredEventAttributes.new(
+      timerId: attrs[:eventId],
+      startedEventId: attrs[:eventId] - 4
+    )
+  end
+end
+
+Fabricator(:timer_canceled_event_thrift, from: :history_event_thrift) do
+  eventType { CadenceThrift::EventType::TimerCanceled }
+  timerCanceledEventAttributes do |attrs|
+    CadenceThrift::TimerCanceledEventAttributes.new(
+      timerId: attrs[:eventId],
+      startedEventId: attrs[:eventId] - 4,
+      decisionTaskCompletedEventId: attrs[:eventId] - 1,
+      identity: 'test-worker@test-host'
+    )
+  end
+end

--- a/spec/unit/lib/cadence/workflow/history/event_spec.rb
+++ b/spec/unit/lib/cadence/workflow/history/event_spec.rb
@@ -1,0 +1,44 @@
+require 'cadence/workflow/history/event'
+
+describe Cadence::Workflow::History::Event do
+  subject { described_class.new(raw_event) }
+
+  describe '#initialize' do
+    let(:raw_event) { Fabricate(:workflow_execution_started_event_thrift) }
+
+    it 'sets correct id' do
+      expect(subject.id).to eq(raw_event.eventId)
+    end
+
+    it 'sets correct timestamp' do
+      current_time = Time.now
+      allow(Time).to receive(:now).and_return(current_time)
+
+      expect(subject.timestamp).to be_within(0.0001).of(current_time)
+    end
+
+    it 'sets correct type' do
+      expect(subject.type).to eq('WorkflowExecutionStarted')
+    end
+
+    it 'sets correct attributes' do
+      expect(subject.attributes).to eq(raw_event.workflowExecutionStartedEventAttributes)
+    end
+  end
+
+  describe '#decision_id' do
+    subject { described_class.new(raw_event).decision_id }
+
+    context 'when event is TimerFired' do
+      let(:raw_event) { Fabricate(:timer_fired_event_thrift, eventId: 42) }
+
+      it { is_expected.to eq(raw_event.timerFiredEventAttributes.startedEventId) }
+    end
+
+    context 'when event is TimerCanceled' do
+      let(:raw_event) { Fabricate(:timer_canceled_event_thrift, eventId: 42) }
+
+      it { is_expected.to eq(raw_event.timerCanceledEventAttributes.startedEventId) }
+    end
+  end
+end

--- a/spec/unit/lib/cadence/workflow/history/event_target_spec.rb
+++ b/spec/unit/lib/cadence/workflow/history/event_target_spec.rb
@@ -1,0 +1,25 @@
+require 'cadence/workflow/history/event_target'
+require 'cadence/workflow/history/event'
+
+describe Cadence::Workflow::History::EventTarget do
+  describe '.from_event' do
+    subject { described_class.from_event(event) }
+    let(:event) { Cadence::Workflow::History::Event.new(raw_event) }
+
+    context 'when event is TimerStarted' do
+      let(:raw_event) { Fabricate(:timer_started_event_thrift) }
+
+      it 'sets type to timer' do
+        expect(subject.type).to eq(described_class::TIMER_TYPE)
+      end
+    end
+
+    context 'when event is TimerCanceled' do
+      let(:raw_event) { Fabricate(:timer_canceled_event_thrift) }
+
+      it 'sets type to cancel_timer_request' do
+        expect(subject.type).to eq(described_class::CANCEL_TIMER_REQUEST_TYPE)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes a bug described in https://github.com/coinbase/temporal-ruby/issues/75

The non-determinism check depends on the class `EventTarget` that creates a canonical event that is used when matching commands to history events (schedule_activity -> activity_scheduled, etc). This allows to check the pending command (not yet sent to Temporal) and history events and remove the ones that are already in the history (in the same order as they were scheduled).

There were 2 bugs with this:
1. When creating an `EventTarget` from an event we did a prefix match favouring the first match. This means that between `ActivityTask` and `ActivityTaskCancel` the first one would win and will generate an incorrect event target (activity, instead of cancel_activity). Fixed by matching all and picking the last match.
2. TimerCanceled event (along with ActivityTaskCanceled) was not discarding a pending command, which it should have. This should be fixed along with `RequestCancelActivityTaskFailed` and `CancelTimerFailed` which should also remove the cancelation command from the pending list

How was it tested?
Specs added, manually tested with a example workflow