### PR TITLE
[Feature] Enable timer operations in testing mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.8
+- Fix issue with incorrect timer cancellation under certain circumstances
+- Implement testing mode support for async timers
+
 ## 0.1.7
 - Update RBI file to remove Thrift methods
 

--- a/examples/activities/async_activity.rb
+++ b/examples/activities/async_activity.rb
@@ -2,6 +2,11 @@ class AsyncActivity < Cadence::Activity
   timeouts start_to_close: 120
 
   def execute
+    # expose async token via a global var for specs
+    # TODO: A much better solution would be to implement a DescribeWorkflowExecution
+    #       call and return the list of pending activities and their async tokens
+    $async_token = activity.async_token
+
     logger.warn "run `bin/activity complete #{activity.async_token}` to complete activity"
 
     activity.async

--- a/examples/bin/worker
+++ b/examples/bin/worker
@@ -11,6 +11,7 @@ worker = Cadence::Worker.new(polling_ttl: 10, thread_pool_size: 20)
 
 worker.register_workflow(AsyncActivityWorkflow)
 worker.register_workflow(AsyncHelloWorldWorkflow)
+worker.register_workflow(AsyncTimerWorkflow)
 worker.register_workflow(BranchingWorkflow)
 worker.register_workflow(CancellingTimerWorkflow)
 worker.register_workflow(CheckWorkflow)

--- a/examples/spec/integration/async_activity_workflow_spec.rb
+++ b/examples/spec/integration/async_activity_workflow_spec.rb
@@ -1,0 +1,34 @@
+require 'workflows/async_activity_workflow'
+require 'securerandom'
+
+describe AsyncActivityWorkflow do
+  let(:workflow_id) { SecureRandom.uuid }
+
+  around do |example|
+    Cadence::Testing.local! { example.run }
+  ensure
+    $async_token = nil
+  end
+
+  context 'when activity completes' do
+    it 'succeeds' do
+      run_id = Cadence.start_workflow(described_class, options: { workflow_id: workflow_id })
+      Cadence.complete_activity($async_token)
+
+      info = Cadence.fetch_workflow_execution_info('ruby-samples', workflow_id, run_id)
+
+      expect(info.status).to eq(Cadence::Workflow::ExecutionInfo::COMPLETED_STATUS)
+    end
+  end
+
+  context 'when activity fails' do
+    it 'fails' do
+      run_id = Cadence.start_workflow(described_class, options: { workflow_id: workflow_id })
+      Cadence.fail_activity($async_token, StandardError.new('test failure'))
+
+      info = Cadence.fetch_workflow_execution_info('ruby-samples', workflow_id, run_id)
+
+      expect(info.status).to eq(Cadence::Workflow::ExecutionInfo::FAILED_STATUS)
+    end
+  end
+end

--- a/examples/spec/integration/async_timer_workflow_spec.rb
+++ b/examples/spec/integration/async_timer_workflow_spec.rb
@@ -1,0 +1,19 @@
+require 'workflows/async_timer_workflow'
+require 'securerandom'
+
+describe AsyncTimerWorkflow do
+  let(:workflow_id) { SecureRandom.uuid }
+
+  around do |example|
+    Cadence::Testing.local! { example.run }
+  end
+
+  it 'succeeds' do
+    run_id = Cadence.start_workflow(described_class, options: { workflow_id: workflow_id })
+    Cadence.fire_timer(workflow_id, run_id, 1)
+
+    info = Cadence.fetch_workflow_execution_info('ruby-samples', workflow_id, run_id)
+
+    expect(info.status).to eq(Cadence::Workflow::ExecutionInfo::COMPLETED_STATUS)
+  end
+end

--- a/examples/spec/integration/async_timer_workflow_spec.rb
+++ b/examples/spec/integration/async_timer_workflow_spec.rb
@@ -16,4 +16,14 @@ describe AsyncTimerWorkflow do
 
     expect(info.status).to eq(Cadence::Workflow::ExecutionInfo::COMPLETED_STATUS)
   end
+
+  it 'executes HelloWorldActivity' do
+    expect_any_instance_of(HelloWorldActivity)
+      .to receive(:execute)
+      .with('timer')
+      .and_call_original
+
+    run_id = Cadence.start_workflow(described_class, options: { workflow_id: workflow_id })
+    Cadence.fire_timer(workflow_id, run_id, 1)
+  end
 end

--- a/examples/spec/integration/cancelling_timer_workflow_spec.rb
+++ b/examples/spec/integration/cancelling_timer_workflow_spec.rb
@@ -1,0 +1,21 @@
+require 'workflows/cancelling_timer_workflow'
+require 'securerandom'
+
+describe CancellingTimerWorkflow do
+  let(:workflow_id) { SecureRandom.uuid }
+  let(:activity_timeout) { 0.01 }
+
+  around do |example|
+    Cadence::Testing.local! { example.run }
+  end
+
+  it 'succeeds' do
+    run_id = Cadence.start_workflow(
+      described_class, activity_timeout, 10, options: { workflow_id: workflow_id }
+    )
+
+    info = Cadence.fetch_workflow_execution_info('ruby-samples', workflow_id, run_id)
+
+    expect(info.status).to eq(Cadence::Workflow::ExecutionInfo::COMPLETED_STATUS)
+  end
+end

--- a/examples/workflows/async_timer_workflow.rb
+++ b/examples/workflows/async_timer_workflow.rb
@@ -1,0 +1,10 @@
+require 'activities/async_activity'
+
+class AsyncTimerWorkflow < Cadence::Workflow
+  def execute
+    timer = workflow.start_timer(30)
+    timer.done { logger.info('Timer fired!') }
+
+    workflow.wait_for(timer)
+  end
+end

--- a/examples/workflows/async_timer_workflow.rb
+++ b/examples/workflows/async_timer_workflow.rb
@@ -1,9 +1,12 @@
-require 'activities/async_activity'
+require 'activities/hello_world_activity'
 
 class AsyncTimerWorkflow < Cadence::Workflow
   def execute
     timer = workflow.start_timer(30)
-    timer.done { logger.info('Timer fired!') }
+    timer.done do
+      logger.info('Timer fired!')
+      HelloWorldActivity.execute!('timer')
+    end
 
     workflow.wait_for(timer)
   end

--- a/lib/cadence/testing/cadence_override.rb
+++ b/lib/cadence/testing/cadence_override.rb
@@ -1,4 +1,5 @@
 require 'securerandom'
+require 'cadence/thread_local_context'
 require 'cadence/activity/async_token'
 require 'cadence/workflow/execution_info'
 require 'cadence/metadata/workflow'
@@ -97,6 +98,8 @@ module Cadence
         context = Cadence::Testing::LocalWorkflowContext.new(
           execution, workflow_id, run_id, workflow.disabled_releases, metadata
         )
+
+        Cadence::ThreadLocalContext.set(context)
 
         execution.run do
           workflow.execute_in_context(context, input)

--- a/lib/cadence/testing/cadence_override.rb
+++ b/lib/cadence/testing/cadence_override.rb
@@ -8,6 +8,11 @@ require 'cadence/testing/local_workflow_context'
 module Cadence
   module Testing
     module CadenceOverride
+      def self.prepended(_mod)
+        # Allow firing timers in testing mode via Cadence API
+        Cadence.def_delegators(:default_client, :fire_timer)
+      end
+
       def start_workflow(workflow, *input, **args)
         return super if Cadence::Testing.disabled?
 
@@ -48,6 +53,13 @@ module Cadence
         execution = executions[[details.workflow_id, details.run_id]]
 
         execution.fail_future(details.activity_id, error)
+      end
+
+      # This method is only available in teesting mode
+      def fire_timer(workflow_id, run_id, timer_id)
+        execution = executions[[workflow_id, run_id]]
+
+        execution.complete_future(timer_id)
       end
 
       private

--- a/lib/cadence/testing/cadence_override.rb
+++ b/lib/cadence/testing/cadence_override.rb
@@ -38,7 +38,7 @@ module Cadence
         details = Activity::AsyncToken.decode(async_token)
         execution = executions[[details.workflow_id, details.run_id]]
 
-        execution.complete_activity(details.activity_id, result)
+        execution.complete_future(details.activity_id, result)
       end
 
       def fail_activity(async_token, error)
@@ -47,7 +47,7 @@ module Cadence
         details = Activity::AsyncToken.decode(async_token)
         execution = executions[[details.workflow_id, details.run_id]]
 
-        execution.fail_activity(details.activity_id, error)
+        execution.fail_future(details.activity_id, error)
       end
 
       private

--- a/lib/cadence/testing/cadence_override.rb
+++ b/lib/cadence/testing/cadence_override.rb
@@ -38,7 +38,7 @@ module Cadence
         details = Activity::AsyncToken.decode(async_token)
         execution = executions[[details.workflow_id, details.run_id]]
 
-        execution.complete_activity(async_token, result)
+        execution.complete_activity(details.activity_id, result)
       end
 
       def fail_activity(async_token, error)
@@ -47,7 +47,7 @@ module Cadence
         details = Activity::AsyncToken.decode(async_token)
         execution = executions[[details.workflow_id, details.run_id]]
 
-        execution.fail_activity(async_token, error)
+        execution.fail_activity(details.activity_id, error)
       end
 
       private

--- a/lib/cadence/testing/future_registry.rb
+++ b/lib/cadence/testing/future_registry.rb
@@ -12,7 +12,9 @@ module Cadence
       end
 
       def complete(id, result)
-        store[id.to_s].set(result)
+        future = store[id.to_s]
+        future.set(result)
+        future.callbacks.each { |callback| callback.call(result) }
       end
 
       def fail(id, error)

--- a/lib/cadence/testing/future_registry.rb
+++ b/lib/cadence/testing/future_registry.rb
@@ -5,18 +5,18 @@ module Cadence
         @store = {}
       end
 
-      def register(token, future)
-        raise 'already registered' if store.key?(token)
+      def register(id, future)
+        raise 'already registered' if store.key?(id.to_s)
 
-        store[token] = future
+        store[id.to_s] = future
       end
 
-      def complete(token, result)
-        store[token].set(result)
+      def complete(id, result)
+        store[id.to_s].set(result)
       end
 
-      def fail(token, error)
-        store[token].fail(error.class.name, error.message)
+      def fail(id, error)
+        store[id.to_s].fail(error.class.name, error.message)
       end
 
       private

--- a/lib/cadence/testing/local_workflow_context.rb
+++ b/lib/cadence/testing/local_workflow_context.rb
@@ -195,7 +195,14 @@ module Cadence
       end
 
       def cancel(target, cancelation_id)
-        raise NotImplementedError, 'not yet available for testing'
+        case target.type
+        when Workflow::History::EventTarget::ACTIVITY_TYPE
+          cancel_activity(cancelation_id)
+        when Workflow::History::EventTarget::TIMER_TYPE
+          cancel_timer(cancelation_id)
+        else
+          raise "#{target} can not be canceled"
+        end
       end
 
       private

--- a/lib/cadence/testing/local_workflow_context.rb
+++ b/lib/cadence/testing/local_workflow_context.rb
@@ -148,11 +148,17 @@ module Cadence
       end
 
       def start_timer(timeout, timer_id = nil)
-        raise NotImplementedError, 'not yet available for testing'
+        event_id = next_event_id
+        timer_id ||= event_id
+
+        target = Workflow::History::EventTarget.new(event_id, Workflow::History::EventTarget::TIMER_TYPE)
+        future = Workflow::Future.new(target, self, cancelation_id: timer_id)
+
+        execution.register_future(timer_id, future)
       end
 
       def cancel_timer(timer_id)
-        raise NotImplementedError, 'not yet available for testing'
+        execution.fail_future(timer_id, RuntimeError.new('timer canceled'))
       end
 
       def complete(result = nil)

--- a/lib/cadence/testing/local_workflow_context.rb
+++ b/lib/cadence/testing/local_workflow_context.rb
@@ -68,6 +68,7 @@ module Cadence
         else
           # Fulfil the future straigt away for non-async activities
           future.set(result)
+          future.callbacks.each { |callback| callback.call(result) }
         end
 
         future

--- a/lib/cadence/testing/local_workflow_context.rb
+++ b/lib/cadence/testing/local_workflow_context.rb
@@ -64,7 +64,7 @@ module Cadence
         result = activity_class.execute_in_context(context, input)
 
         if context.async?
-          execution.register_future(context.async_token, future)
+          execution.register_future(activity_id, future)
         else
           # Fulfil the future straigt away for non-async activities
           future.set(result)

--- a/lib/cadence/testing/workflow_execution.rb
+++ b/lib/cadence/testing/workflow_execution.rb
@@ -26,12 +26,12 @@ module Cadence
         futures.register(id, future)
       end
 
-      def complete_activity(id, result)
+      def complete_future(id, result = nil)
         futures.complete(id, result)
         resume
       end
 
-      def fail_activity(id, error)
+      def fail_future(id, error)
         futures.fail(id, error)
         resume
       end

--- a/lib/cadence/testing/workflow_execution.rb
+++ b/lib/cadence/testing/workflow_execution.rb
@@ -22,17 +22,17 @@ module Cadence
         @status = Workflow::ExecutionInfo::FAILED_STATUS
       end
 
-      def register_future(token, future)
-        futures.register(token, future)
+      def register_future(id, future)
+        futures.register(id, future)
       end
 
-      def complete_activity(token, result)
-        futures.complete(token, result)
+      def complete_activity(id, result)
+        futures.complete(id, result)
         resume
       end
 
-      def fail_activity(token, error)
-        futures.fail(token, error)
+      def fail_activity(id, error)
+        futures.fail(id, error)
         resume
       end
 

--- a/lib/cadence/version.rb
+++ b/lib/cadence/version.rb
@@ -1,3 +1,3 @@
 module Cadence
-  VERSION = '0.1.7'.freeze
+  VERSION = '0.1.8'.freeze
 end


### PR DESCRIPTION
This PR implements all the required capabilities to test async timers. Right now these are not actually counting the time (which would be really difficult to test), however can be fired off manually when needed. Any set callback will also get executed.

The timer can be fired off using a new (testing-only) API — `Cadence.fire_timer`

Tested with new unit and integration specs