### PR TITLE
Fix timer cancellation regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.9
+- Fix regression with non-deterministic timer cancellation
+
 ## 0.1.8
 - Fix issue with incorrect timer cancellation under certain circumstances
 - Implement testing mode support for async timers

--- a/lib/cadence/version.rb
+++ b/lib/cadence/version.rb
@@ -1,3 +1,3 @@
 module Cadence
-  VERSION = '0.1.8'.freeze
+  VERSION = '0.1.9'.freeze
 end

--- a/lib/cadence/workflow/history/event.rb
+++ b/lib/cadence/workflow/history/event.rb
@@ -45,7 +45,7 @@ module Cadence
         # referred to as a "decision" event. Not related to DecisionTask.
         def decision_id
           case type
-          when 'TimerFired', 'TimerCanceled'
+          when 'TimerFired'
             attributes.startedEventId
           when 'WorkflowExecutionSignaled'
             1 # fixed id for everything related to current workflow

--- a/spec/unit/lib/cadence/workflow/history/event_spec.rb
+++ b/spec/unit/lib/cadence/workflow/history/event_spec.rb
@@ -38,7 +38,7 @@ describe Cadence::Workflow::History::Event do
     context 'when event is TimerCanceled' do
       let(:raw_event) { Fabricate(:timer_canceled_event_thrift, eventId: 42) }
 
-      it { is_expected.to eq(raw_event.timerCanceledEventAttributes.startedEventId) }
+      it { is_expected.to eq(raw_event.eventId) }
     end
   end
 end


### PR DESCRIPTION
#56 has introduced a regression which would associate timer cancelation request with the timer itself resulting in a non-deterministic replay (attempting to match timer's cancellation with initiation of the timer, which are two separate commands).

It was tested using a sample workflow and a unit spec