### PR TITLE
[Feature] Add id and domain to workflow context's metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.10
+- Add :id and :domain to workflow context's metadata
+
 ## 0.1.9
 - Fix regression with non-deterministic timer cancellation
 

--- a/lib/cadence/metadata.rb
+++ b/lib/cadence/metadata.rb
@@ -7,17 +7,14 @@ module Cadence
   module Metadata
     ACTIVITY_TYPE = :activity
     DECISION_TYPE = :decision
-    WORKFLOW_TYPE = :workflow
 
     class << self
-      def generate(type, data, domain = nil)
+      def generate(type, data, domain)
         case type
         when ACTIVITY_TYPE
           activity_metadata_from(data, domain)
         when DECISION_TYPE
           decision_metadata_from(data, domain)
-        when WORKFLOW_TYPE
-          workflow_metadata_from(data)
         else
           raise InternalError, 'Unsupported metadata type'
         end
@@ -53,21 +50,6 @@ module Cadence
           workflow_run_id: task.workflowExecution.runId,
           workflow_id: task.workflowExecution.workflowId,
           workflow_name: task.workflowType.name
-        )
-      end
-
-      def workflow_metadata_from(event)
-        Metadata::Workflow.new(
-          domain: nil,
-          id: nil,
-          name: event.workflowType.name,
-          run_id: event.originalExecutionRunId,
-          attempt: event.attempt,
-          headers: event.header&.fields || {},
-          timeouts: {
-            execution: event.executionStartToCloseTimeoutSeconds,
-            task: event.taskStartToCloseTimeoutSeconds
-          }
         )
       end
     end

--- a/lib/cadence/metadata.rb
+++ b/lib/cadence/metadata.rb
@@ -58,6 +58,8 @@ module Cadence
 
       def workflow_metadata_from(event)
         Metadata::Workflow.new(
+          domain: nil,
+          id: nil,
           name: event.workflowType.name,
           run_id: event.originalExecutionRunId,
           attempt: event.attempt,

--- a/lib/cadence/metadata/workflow.rb
+++ b/lib/cadence/metadata/workflow.rb
@@ -3,9 +3,11 @@ require 'cadence/metadata/base'
 module Cadence
   module Metadata
     class Workflow < Base
-      attr_reader :name, :run_id, :attempt, :headers, :timeouts
+      attr_reader :domain, :id, :name, :run_id, :attempt, :headers, :timeouts
 
-      def initialize(name:, run_id:, attempt:, timeouts:, headers: {})
+      def initialize(domain:, id:, name:, run_id:, attempt:, timeouts:, headers: {})
+        @domain = domain
+        @id = id
         @name = name
         @run_id = run_id
         @attempt = attempt
@@ -21,6 +23,8 @@ module Cadence
 
       def to_h
         {
+          domain: domain,
+          workflow_id: id,
           workflow_name: name,
           workflow_run_id: run_id,
           attempt: attempt

--- a/lib/cadence/testing/cadence_override.rb
+++ b/lib/cadence/testing/cadence_override.rb
@@ -88,7 +88,9 @@ module Cadence
         execution_options = ExecutionOptions.new(workflow, options)
 
         metadata = Cadence::Metadata::Workflow.new(
-          name: workflow_id,
+          domain: execution_options.domain,
+          id: workflow_id,
+          name: execution_options.name,
           run_id: run_id,
           attempt: 1,
           timeouts: {},

--- a/lib/cadence/testing/workflow_override.rb
+++ b/lib/cadence/testing/workflow_override.rb
@@ -27,7 +27,9 @@ module Cadence
         run_id = SecureRandom.uuid
         execution = WorkflowExecution.new
         metadata = Cadence::Metadata::Workflow.new(
-          name: workflow_id,
+          domain: nil,
+          id: workflow_id,
+          name: name, # Workflow class name
           run_id: run_id,
           attempt: 1,
           timeouts: {}

--- a/lib/cadence/version.rb
+++ b/lib/cadence/version.rb
@@ -1,3 +1,3 @@
 module Cadence
-  VERSION = '0.1.9'.freeze
+  VERSION = '0.1.10'.freeze
 end

--- a/lib/cadence/workflow/decision_task_processor.rb
+++ b/lib/cadence/workflow/decision_task_processor.rb
@@ -33,7 +33,7 @@ module Cadence
 
         history = fetch_full_history
         # TODO: For sticky workflows we need to cache the Executor instance
-        executor = Workflow::Executor.new(workflow_class, history, config)
+        executor = Workflow::Executor.new(workflow_class, history, metadata, config)
 
         decisions = middleware_chain.invoke(metadata) do
           executor.run

--- a/lib/cadence/workflow/executor.rb
+++ b/lib/cadence/workflow/executor.rb
@@ -4,6 +4,7 @@ require 'cadence/workflow/dispatcher'
 require 'cadence/workflow/state_manager'
 require 'cadence/workflow/context'
 require 'cadence/workflow/history/event_target'
+require 'cadence/metadata'
 
 module Cadence
   class Workflow
@@ -34,7 +35,8 @@ module Cadence
 
       attr_reader :workflow_class, :dispatcher, :state_manager, :history, :config
 
-      def execute_workflow(input, metadata)
+      def execute_workflow(input, workflow_started_event_attributes)
+        metadata = Metadata.generate(Metadata::WORKFLOW_TYPE, workflow_started_event_attributes)
         context = Workflow::Context.new(state_manager, dispatcher, metadata, config)
 
         Fiber.new do

--- a/lib/cadence/workflow/state_manager.rb
+++ b/lib/cadence/workflow/state_manager.rb
@@ -3,7 +3,6 @@ require 'cadence/errors'
 require 'cadence/workflow/decision'
 require 'cadence/workflow/decision_state_machine'
 require 'cadence/workflow/history/event_target'
-require 'cadence/metadata'
 
 module Cadence
   class Workflow
@@ -102,7 +101,7 @@ module Cadence
             History::EventTarget.workflow,
             'started',
             safe_parse(event.attributes.input),
-            Metadata.generate(Metadata::WORKFLOW_TYPE, event.attributes)
+            event.attributes
           )
 
         when 'WorkflowExecutionCompleted'

--- a/spec/fabricators/workflow_metadata_fabricator.rb
+++ b/spec/fabricators/workflow_metadata_fabricator.rb
@@ -1,6 +1,8 @@
 require 'securerandom'
 
 Fabricator(:workflow_metadata, from: :open_struct) do
+  domain 'test-domain'
+  id { SecureRandom.uuid }
   name 'TestWorkflow'
   run_id { SecureRandom.uuid }
   attempt 1

--- a/spec/unit/lib/cadence/activity/task_processor_spec.rb
+++ b/spec/unit/lib/cadence/activity/task_processor_spec.rb
@@ -10,7 +10,7 @@ describe Cadence::Activity::TaskProcessor do
   let(:task) do
     Fabricate(:activity_task_thrift, activity_name: activity_name, input: Cadence::JSON.serialize(input))
   end
-  let(:metadata) { Cadence::Metadata.generate(Cadence::Metadata::ACTIVITY_TYPE, task) }
+  let(:metadata) { Cadence::Metadata.generate(Cadence::Metadata::ACTIVITY_TYPE, task, domain) }
   let(:activity_name) { 'TestActivity' }
   let(:connection) { instance_double('Cadence::Connection::Thrift') }
   let(:middleware_chain) { Cadence::Middleware::Chain.new }

--- a/spec/unit/lib/cadence/metadata/workflow_spec.rb
+++ b/spec/unit/lib/cadence/metadata/workflow_spec.rb
@@ -6,6 +6,8 @@ describe Cadence::Metadata::Workflow do
 
   describe '#initialize' do
     it 'sets the attributes' do
+      expect(subject.domain).to eq(args.domain)
+      expect(subject.id).to eq(args.id)
       expect(subject.name).to eq(args.name)
       expect(subject.run_id).to eq(args.run_id)
       expect(subject.attempt).to eq(args.attempt)
@@ -22,6 +24,8 @@ describe Cadence::Metadata::Workflow do
   describe '#to_h' do
     it 'returns a hash' do
       expect(subject.to_h).to eq(
+        domain: subject.domain,
+        workflow_id: subject.id,
         attempt: subject.attempt,
         workflow_name: subject.name,
         workflow_run_id: subject.run_id

--- a/spec/unit/lib/cadence/metadata_spec.rb
+++ b/spec/unit/lib/cadence/metadata_spec.rb
@@ -46,28 +46,6 @@ describe Cadence::Metadata do
       end
     end
 
-    context 'with workflow type' do
-      let(:type) { described_class::WORKFLOW_TYPE }
-      let(:data) { Fabricate(:worklfow_execution_started_event_attributes_thrift) }
-      let(:domain) { nil }
-
-      it 'generates metadata' do
-        expect(subject.run_id).to eq(data.originalExecutionRunId)
-        expect(subject.attempt).to eq(data.attempt)
-        expect(subject.headers).to eq({})
-      end
-
-      context 'with headers' do
-        let(:data) do
-          Fabricate(:worklfow_execution_started_event_attributes_thrift, headers: { 'Foo' => 'Bar' })
-        end
-
-        it 'assigns headers' do
-          expect(subject.headers).to eq('Foo' => 'Bar')
-        end
-      end
-    end
-
     context 'with unknown type' do
       let(:type) { :unknown }
       let(:data) { nil }

--- a/spec/unit/lib/cadence/workflow/context_spec.rb
+++ b/spec/unit/lib/cadence/workflow/context_spec.rb
@@ -10,6 +10,8 @@ describe Cadence::Workflow::Context do
     let(:dispatcher) { Cadence::Workflow::Dispatcher.new }
     let(:metadata_hash) do
       {
+        domain: 'test-domain',
+        id: SecureRandom.uuid,
         name: 'TestWorkflow',
         run_id: SecureRandom.uuid,
         attempt: 0,

--- a/spec/unit/lib/cadence/workflow/decision_task_processor_spec.rb
+++ b/spec/unit/lib/cadence/workflow/decision_task_processor_spec.rb
@@ -49,7 +49,7 @@ describe Cadence::Workflow::DecisionTaskProcessor do
 
       allow(Cadence::Workflow::Executor)
         .to receive(:new)
-        .with(TestWorkflow, an_instance_of(Cadence::Workflow::History), config)
+        .with(TestWorkflow, an_instance_of(Cadence::Workflow::History), metadata, config)
         .and_return(executor)
     end
 

--- a/spec/unit/lib/cadence/workflow/executor_spec.rb
+++ b/spec/unit/lib/cadence/workflow/executor_spec.rb
@@ -1,0 +1,76 @@
+require 'cadence/workflow/executor'
+require 'cadence/workflow/history'
+require 'cadence/workflow'
+
+describe Cadence::Workflow::Executor do
+  subject { described_class.new(workflow, history, decision_metadata, config) }
+
+  let(:workflow_started_event) { Fabricate(:workflow_execution_started_event_thrift, eventId: 1) }
+  let(:history) do
+    Cadence::Workflow::History.new([
+      workflow_started_event,
+      Fabricate(:decision_task_scheduled_event_thrift, eventId: 2),
+      Fabricate(:decision_task_started_event_thrift, eventId: 3),
+      Fabricate(:decision_task_completed_event_thrift, eventId: 4)
+    ])
+  end
+  let(:workflow) { TestWorkflow }
+  let(:decision_metadata) { Fabricate(:decision_metadata) }
+  let(:config) { Cadence::Configuration.new }
+
+  class TestWorkflow < Cadence::Workflow
+    def execute
+      'test'
+    end
+  end
+
+  describe '#run' do
+    it 'runs a workflow' do
+      allow(workflow).to receive(:execute_in_context).and_call_original
+
+      subject.run
+
+      expect(workflow)
+        .to have_received(:execute_in_context)
+        .with(
+          an_instance_of(Cadence::Workflow::Context),
+          nil
+        )
+    end
+
+    it 'returns a complete workflow decision' do
+      decisions = subject.run
+
+      expect(decisions.length).to eq(1)
+
+      decision_id, decision = decisions.first
+      expect(decision_id).to eq(history.events.length + 1)
+      expect(decision).to be_an_instance_of(Cadence::Workflow::Decision::CompleteWorkflow)
+      expect(decision.result).to eq('test')
+    end
+
+    it 'generates workflow metadata' do
+      allow(Cadence::Metadata::Workflow).to receive(:new).and_call_original
+      workflow_started_event.workflowExecutionStartedEventAttributes.header =
+        Fabricate(:header_thrift, fields: { 'Foo' => 'Bar' })
+
+      subject.run
+
+      event_attributes = workflow_started_event.workflowExecutionStartedEventAttributes
+      expect(Cadence::Metadata::Workflow)
+        .to have_received(:new)
+        .with(
+          domain: decision_metadata.domain,
+          id: decision_metadata.workflow_id,
+          name: event_attributes.workflowType.name,
+          run_id: event_attributes.originalExecutionRunId,
+          attempt: event_attributes.attempt,
+          headers: { 'Foo' => 'Bar' },
+          timeouts: {
+            execution: event_attributes.executionStartToCloseTimeoutSeconds,
+            task: event_attributes.taskStartToCloseTimeoutSeconds
+          }
+        )
+    end
+  end
+end


### PR DESCRIPTION
There are 3 types of metadata — decision, activity and workflow. Each is exposed to different parts of the SDK.

Workflow ID is generated from the history, which confusingly doesn't have domain or workflow_id. This PR adds these 2 missing fields from the decision metadata

Tested using unit specs and manual workflow runs