### PR TITLE
Add a Crew implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.14
+- Add a Crew implementation to fork and manage worker child processes
+
 ## 0.1.13
 - Add methods for fetching workflow executions (`#list_open_workflow_executions` and `#list_closed_workflow_executions`)
 

--- a/examples/bin/worker
+++ b/examples/bin/worker
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require_relative '../init'
 
+require 'cadence/crew'
 require 'cadence/worker'
 
 Dir[File.expand_path('../workflows/*.rb', __dir__)].each { |f| require f }
@@ -49,4 +50,10 @@ worker.register_activity(Trip::RentCarActivity)
 worker.add_decision_middleware(LoggingMiddleware, 'EXAMPLE')
 worker.add_activity_middleware(LoggingMiddleware, 'EXAMPLE')
 
-worker.start
+option1 = ARGV[0]
+if option1 == '--crew'
+  crew = Cadence::Crew.new(worker, 2)
+  crew.dispatch
+else
+  worker.start
+end

--- a/lib/cadence/crew.rb
+++ b/lib/cadence/crew.rb
@@ -1,0 +1,65 @@
+require 'logger'
+
+module Cadence
+
+  # Creates a group of child worker processes and tracks their state
+  # Params:
+  # +worker+:: The worker that will be forked and duplicated in child processes
+  # +crew_size+:: The number of workers that will be created
+  class Crew
+    attr_reader :crew_size
+
+    def initialize(worker, crew_size)
+      @worker = worker
+      @crew = []
+      @crew_size = crew_size
+      @logger = Logger.new(STDOUT, progname: 'cadence_client')
+    end
+
+    # Creates the worker processes and starts monitoring them
+    def dispatch
+      logger.info "Dispatching crew. Size: #{crew_size}"
+      trap_signals
+      (1..crew_size).each { dispatch_worker }
+      monitor
+    end
+
+    # Stops the child worker processes
+    def stop(signal)
+      logger.info 'Stopping crew'
+      crew.each { |pid| stop_worker(signal, pid) }
+    end
+
+    private
+
+    attr_reader :worker, :crew, :logger
+
+    def dispatch_worker
+      pid = fork { worker.start }
+      crew << pid
+      logger.info "Worker started. pid: #{pid}"
+      pid
+    end
+
+    def monitor
+      while crew.length.positive?
+        (pid, status) = ::Process.waitpid2(-1)
+        crew.delete(pid)
+        logger.info "Worker quit. pid: #{pid.to_s}, exitstatus: #{status.exitstatus}, remaining_workers: #{crew.length}"
+      end
+
+      logger.info 'The crew has finished up!'
+    end
+
+    def stop_worker(signal, pid)
+      logger.info "Sending signal to worker. pid: #{pid}, signal: #{signal}"
+      Process.kill(signal, pid)
+    end
+
+    def trap_signals
+      %w[TERM INT].each do |signal|
+        Signal.trap(signal) { stop(signal) }
+      end
+    end
+  end
+end

--- a/lib/cadence/version.rb
+++ b/lib/cadence/version.rb
@@ -1,3 +1,3 @@
 module Cadence
-  VERSION = '0.1.13'.freeze
+  VERSION = '0.1.14'.freeze
 end

--- a/spec/unit/lib/cadence/crew_spec.rb
+++ b/spec/unit/lib/cadence/crew_spec.rb
@@ -1,0 +1,86 @@
+require 'cadence/configuration'
+require 'cadence/crew'
+require 'cadence/worker'
+
+describe Cadence::Crew do
+  subject { described_class.new(mock_worker, crew_size) }
+  let(:crew_size) { 2 }
+  let(:mock_worker) { instance_double('Cadence::Worker') }
+
+  it 'stores the crew size' do
+    expect(subject.crew_size).to eq(2)
+  end
+
+  describe '#dispatch' do
+    let(:pid) { 1 }
+
+    it 'should fork and start the worker n times' do
+      Status = Struct.new(:exitstatus)
+      status = Status.new(0)
+
+      allow(subject).to receive(:fork).and_return(pid).and_yield
+      allow(mock_worker).to receive(:start) { nil }
+      allow(Process).to receive(:waitpid2).and_return([pid, status])
+
+      subject.dispatch
+
+      expect(subject).to have_received(:fork).twice
+      expect(mock_worker).to have_received(:start).twice
+      expect(subject.send(:crew).size).to eq(0)
+    end
+
+    describe 'signal handling' do
+      let(:real_worker) { Cadence::Worker.new(Cadence::Configuration.new) }
+      let(:real_crew) { described_class.new(real_worker, crew_size) }
+      let(:thread_sync_delay) { 1.5 }
+
+      before do
+        @thread = Thread.new { real_crew.dispatch }
+        sleep 0.1 # give crew time to start
+      end
+
+      around do |example|
+        # Trick RSpec into not shutting itself down on TERM signal
+        old_term_handler = Signal.trap('TERM', 'SYSTEM_DEFAULT')
+        old_int_handler = Signal.trap('INT', 'SYSTEM_DEFAULT')
+
+        example.run
+
+        # Restore the original signal handling behaviour
+        Signal.trap('TERM', old_term_handler)
+        Signal.trap('INT', old_int_handler)
+      end
+
+      it 'traps TERM signal' do
+        Process.kill('TERM', 0)
+        sleep thread_sync_delay
+
+        expect(@thread).not_to be_alive
+      end
+
+      it 'traps INT signal' do
+        Process.kill('INT', 0)
+        sleep thread_sync_delay
+
+        expect(@thread).not_to be_alive
+      end
+    end
+
+  end
+
+  describe 'stop' do
+    let(:real_worker) { Cadence::Worker.new(Cadence::Configuration.new) }
+    let(:real_crew) { described_class.new(real_worker, crew_size) }
+    let(:thread_sync_delay) { 0.1 }
+
+    it 'stops the child workers' do
+      @thread = Thread.new { real_crew.dispatch }
+      sleep thread_sync_delay
+      expect(real_crew.send(:crew).size).to eq(crew_size)
+
+      real_crew.stop('TERM')
+      sleep thread_sync_delay
+      expect(subject.send(:crew).size).to eq(0)
+    end
+  end
+end

--- a/spec/unit/lib/cadence/crew_spec.rb
+++ b/spec/unit/lib/cadence/crew_spec.rb
@@ -32,7 +32,7 @@ describe Cadence::Crew do
     describe 'signal handling' do
       let(:real_worker) { Cadence::Worker.new(Cadence::Configuration.new) }
       let(:real_crew) { described_class.new(real_worker, crew_size) }
-      let(:thread_sync_delay) { 1.5 }
+      let(:thread_sync_delay) { 2 }
 
       before do
         @thread = Thread.new { real_crew.dispatch }


### PR DESCRIPTION
Because of the limitations Ruby has with multi-threading we find ourselves starting up multiple worker processes on our instances.  Currently we manage this with docker containers and lots of copy-paste.

This PR adds the notion of a "crew" of workers. When a crew is dispatched it simply forks the worker given `n` times and relays any TERM or INT signals given to all child processes.