### PR TITLE
Add an after_fork hook to the crew class

### DIFF
--- a/examples/bin/crew
+++ b/examples/bin/crew
@@ -1,0 +1,57 @@
+#!/usr/bin/env ruby
+require_relative '../init'
+
+require 'cadence/crew'
+require 'cadence/worker'
+
+init = proc do |worker|
+  Dir[File.expand_path('../workflows/*.rb', __dir__)].each { |f| require f }
+  Dir[File.expand_path('../activities/*.rb', __dir__)].each { |f| require f }
+  Dir[File.expand_path('../middleware/*.rb', __dir__)].each { |f| require f }
+
+  worker.register_workflow(AsyncActivityWorkflow)
+  worker.register_workflow(AsyncHelloWorldWorkflow)
+  worker.register_workflow(AsyncTimerWorkflow)
+  worker.register_workflow(BranchingWorkflow)
+  worker.register_workflow(CancellingTimerWorkflow)
+  worker.register_workflow(CheckWorkflow)
+  worker.register_workflow(FailingWorkflow)
+  worker.register_workflow(HelloWorldWorkflow)
+  worker.register_workflow(LocalHelloWorldWorkflow)
+  worker.register_workflow(LongWorkflow)
+  worker.register_workflow(ParentWorkflow)
+  worker.register_workflow(ProcessFileWorkflow)
+  worker.register_workflow(ReleaseWorkflow)
+  worker.register_workflow(SerialHelloWorldWorkflow)
+  worker.register_workflow(SideEffectWorkflow)
+  worker.register_workflow(SimpleTimerWorkflow)
+  worker.register_workflow(TimeoutWorkflow)
+  worker.register_workflow(TripBookingWorkflow)
+  worker.register_workflow(GrpcClientWorkflow)
+
+  worker.register_activity(AsyncActivity)
+  worker.register_activity(EchoActivity)
+  worker.register_activity(GenerateFileActivity)
+  worker.register_activity(HelloWorldActivity)
+  worker.register_activity(LongRunningActivity)
+  worker.register_activity(ProcessFileActivity)
+  worker.register_activity(RandomlyFailingActivity)
+  worker.register_activity(RandomNumberActivity)
+  worker.register_activity(SleepActivity)
+  worker.register_activity(UploadFileActivity)
+  worker.register_activity(Trip::BookFlightActivity)
+  worker.register_activity(Trip::BookHotelActivity)
+  worker.register_activity(Trip::CancelCarActivity)
+  worker.register_activity(Trip::CancelFlightActivity)
+  worker.register_activity(Trip::CancelHotelActivity)
+  worker.register_activity(Trip::MakePaymentActivity)
+  worker.register_activity(Trip::RentCarActivity)
+
+  worker.add_decision_middleware(LoggingMiddleware, 'EXAMPLE')
+  worker.add_activity_middleware(LoggingMiddleware, 'EXAMPLE')
+end
+
+worker = Cadence::Worker.new(polling_ttl: 10, thread_pool_size: 20)
+crew = Cadence::Crew.new(worker, 2)
+crew.after_fork init
+crew.dispatch

--- a/examples/bin/crew
+++ b/examples/bin/crew
@@ -27,7 +27,6 @@ init = proc do |worker|
   worker.register_workflow(SimpleTimerWorkflow)
   worker.register_workflow(TimeoutWorkflow)
   worker.register_workflow(TripBookingWorkflow)
-  worker.register_workflow(GrpcClientWorkflow)
 
   worker.register_activity(AsyncActivity)
   worker.register_activity(EchoActivity)

--- a/examples/bin/crew
+++ b/examples/bin/crew
@@ -52,5 +52,5 @@ end
 
 worker = Cadence::Worker.new(polling_ttl: 10, thread_pool_size: 20)
 crew = Cadence::Crew.new(worker, 2)
-crew.after_fork init
+crew.after_fork &init
 crew.dispatch

--- a/examples/bin/worker
+++ b/examples/bin/worker
@@ -50,10 +50,4 @@ worker.register_activity(Trip::RentCarActivity)
 worker.add_decision_middleware(LoggingMiddleware, 'EXAMPLE')
 worker.add_activity_middleware(LoggingMiddleware, 'EXAMPLE')
 
-option1 = ARGV[0]
-if option1 == '--crew'
-  crew = Cadence::Crew.new(worker, 2)
-  crew.dispatch
-else
-  worker.start
-end
+worker.start

--- a/lib/cadence/crew.rb
+++ b/lib/cadence/crew.rb
@@ -40,7 +40,7 @@ module Cadence
     private
 
     attr_accessor :after_fork_block
-    attr_reader :worker, :crew, :logger, :after_fork_block
+    attr_reader :worker, :crew, :logger
 
     def dispatch_worker
       pid = fork do

--- a/lib/cadence/crew.rb
+++ b/lib/cadence/crew.rb
@@ -31,7 +31,7 @@ module Cadence
       crew.each { |pid| stop_worker(signal, pid) }
     end
 
-    def after_fork(block)
+    def after_fork(&block)
       raise 'after_fork can only be called before dispatching the worker' if crew.length.positive?
 
       @after_fork_block = block

--- a/lib/cadence/crew.rb
+++ b/lib/cadence/crew.rb
@@ -31,12 +31,23 @@ module Cadence
       crew.each { |pid| stop_worker(signal, pid) }
     end
 
+    def after_fork(block)
+      raise 'after_fork can only be called before dispatching the worker' if crew.length.positive?
+
+      @after_fork_block = block
+    end
+
     private
 
-    attr_reader :worker, :crew, :logger
+    attr_accessor :after_fork_block
+    attr_reader :worker, :crew, :logger, :after_fork_block
 
     def dispatch_worker
-      pid = fork { worker.start }
+      pid = fork do
+        after_fork_block&.call(worker)
+        worker.start
+      end
+
       crew << pid
 
       Cadence.metrics.gauge("crew.num_workers", crew.size)
@@ -49,7 +60,7 @@ module Cadence
       while crew.length.positive?
         (pid, status) = ::Process.waitpid2(-1)
         crew.delete(pid)
-        
+
         Cadence.metrics.gauge("crew.num_workers", crew.size)
         logger.info "Worker quit. pid: #{pid.to_s}, exitstatus: #{status.exitstatus}, remaining_workers: #{crew.length}"
       end

--- a/rbi/cadence-ruby.rbi
+++ b/rbi/cadence-ruby.rbi
@@ -140,6 +140,8 @@ class Cadence::Worker
 end
 
 class Cadence::Crew
+    def after_fork(block); end
+
     def dispatch; end
 
     def stop(signal); end

--- a/spec/unit/lib/cadence/crew_spec.rb
+++ b/spec/unit/lib/cadence/crew_spec.rb
@@ -91,7 +91,7 @@ describe Cadence::Crew do
           executed = true
         end
 
-        crew.after_fork(after_fork_block)
+        crew.after_fork &after_fork_block
 
         crew.should_receive(:fork) do |&block|
           block.call

--- a/spec/unit/lib/cadence/crew_spec.rb
+++ b/spec/unit/lib/cadence/crew_spec.rb
@@ -66,6 +66,42 @@ describe Cadence::Crew do
       end
     end
 
+    describe 'after_fork' do
+      let(:worker) { Cadence::Worker.new(Cadence::Configuration.new) }
+      let(:crew) { described_class.new(worker, 1) }
+
+      before do
+        allow(worker).to receive(:start) { nil }
+        allow(crew).to receive(:monitor) { nil }
+      end
+
+      it 'skips the after_fork block if not set' do
+        crew.should_receive(:fork) do |&block|
+          expect(worker).to receive(:start)
+          expect(crew.send(:after_fork_block)).to be_nil
+          block.call
+        end
+
+        crew.dispatch
+      end
+
+      it 'executes the after_fork block if set' do
+        executed = false
+        after_fork_block = proc do |worker|
+          executed = true
+        end
+
+        crew.after_fork(after_fork_block)
+
+        crew.should_receive(:fork) do |&block|
+          block.call
+          expect(executed).to eq(true)
+          expect(worker).to have_received(:start)
+        end
+
+        crew.dispatch
+      end
+    end
   end
 
   describe 'stop' do


### PR DESCRIPTION
We ran into [this issue](https://github.com/grpc/grpc/issues/7951) when attempting to roll out the crew feature. To work around that we'll need to initialize all of our workflows and activities in the forked process instead of the main process. So this PR adds an `after_fork` block that we can set to do that initialization.

automerge=true