### PR TITLE
Add header propagation and workflow middleware.

### DIFF
--- a/examples/bin/trigger
+++ b/examples/bin/trigger
@@ -2,6 +2,7 @@
 require_relative '../init'
 
 Dir[File.expand_path('../workflows/*.rb', __dir__)].each { |f| require f }
+Dir[File.expand_path('../middleware/*.rb', __dir__)].each { |f| require f }
 
 workflow_class_name, *args = ARGV
 workflow_class = Object.const_get(workflow_class_name)
@@ -9,6 +10,10 @@ workflow_id = SecureRandom.uuid
 
 # Convert integer strings to integers
 input = args.map { |arg| Integer(arg) rescue arg }
+
+Cadence.configure do |config|
+  config.add_header_propagator(SamplePropagator)
+end
 
 run_id = Cadence.start_workflow(workflow_class, *input, options: { workflow_id: workflow_id })
 Cadence.logger.info "Started workflow: #{run_id} / #{workflow_id}"

--- a/examples/bin/worker
+++ b/examples/bin/worker
@@ -8,6 +8,10 @@ Dir[File.expand_path('../workflows/*.rb', __dir__)].each { |f| require f }
 Dir[File.expand_path('../activities/*.rb', __dir__)].each { |f| require f }
 Dir[File.expand_path('../middleware/*.rb', __dir__)].each { |f| require f }
 
+Cadence.configure do |config|
+  config.add_header_propagator(SamplePropagator)
+end
+
 worker = Cadence::Worker.new(polling_ttl: 10, thread_pool_size: 20)
 
 worker.register_workflow(AsyncActivityWorkflow)
@@ -49,5 +53,7 @@ worker.register_activity(Trip::RentCarActivity)
 
 worker.add_decision_middleware(LoggingMiddleware, 'EXAMPLE')
 worker.add_activity_middleware(LoggingMiddleware, 'EXAMPLE')
+worker.add_activity_middleware(SamplePropagator)
+worker.add_workflow_middleware(SamplePropagator)
 
 worker.start

--- a/examples/middleware/sample_propagator.rb
+++ b/examples/middleware/sample_propagator.rb
@@ -1,0 +1,10 @@
+class SamplePropagator
+  def inject!(headers)
+    headers['test-header'] = 'test'
+  end
+
+  def call(metadata)
+    Cadence.logger.info("Got headers! #{metadata.headers.to_h}")
+    yield
+  end
+end

--- a/lib/cadence/client.rb
+++ b/lib/cadence/client.rb
@@ -30,7 +30,7 @@ module Cadence
         execution_timeout: execution_options.timeouts[:execution],
         task_timeout: execution_options.timeouts[:task],
         workflow_id_reuse_policy: options[:workflow_id_reuse_policy],
-        headers: execution_options.headers
+        headers: config.header_propagator_chain.inject(execution_options.headers)
       )
 
       response.runId
@@ -52,7 +52,7 @@ module Cadence
         execution_timeout: execution_options.timeouts[:execution],
         task_timeout: execution_options.timeouts[:task],
         workflow_id_reuse_policy: options[:workflow_id_reuse_policy],
-        headers: execution_options.headers,
+        headers: config.header_propagator_chain.inject(execution_options.headers),
         cron_schedule: cron_schedule
       )
 

--- a/lib/cadence/middleware/header_propagator_chain.rb
+++ b/lib/cadence/middleware/header_propagator_chain.rb
@@ -1,0 +1,22 @@
+module Cadence
+  module Middleware
+    class HeaderPropagatorChain
+      def initialize(entries = [])
+        @propagators = entries.map(&:init_middleware)
+      end
+
+      def inject(headers)
+        return headers if propagators.empty?
+        h = headers.dup
+        for propagator in propagators
+          propagator.inject!(h)
+        end
+        h
+      end
+
+      private
+
+      attr_reader :propagators
+    end
+  end
+end

--- a/lib/cadence/worker.rb
+++ b/lib/cadence/worker.rb
@@ -14,6 +14,7 @@ module Cadence
       @pollers = []
       @decision_middleware = []
       @activity_middleware = []
+      @workflow_middleware = []
       @shutting_down = false
     end
 
@@ -37,6 +38,10 @@ module Cadence
 
     def add_activity_middleware(middleware_class, *args)
       @activity_middleware << Middleware::Entry.new(middleware_class, args)
+    end
+
+    def add_workflow_middleware(middleware_class, *args)
+      @workflow_middleware << Middleware::Entry.new(middleware_class, args)
     end
 
     def start
@@ -68,14 +73,14 @@ module Cadence
     private
 
     attr_reader :config, :options, :activities, :workflows, :pollers,
-                :decision_middleware, :activity_middleware
+                :decision_middleware, :activity_middleware, :workflow_middleware
 
     def shutting_down?
       @shutting_down
     end
 
     def workflow_poller_for(domain, task_list, lookup)
-      Workflow::Poller.new(domain, task_list, lookup.freeze, config, decision_middleware, options)
+      Workflow::Poller.new(domain, task_list, lookup.freeze, config, decision_middleware, workflow_middleware, options)
     end
 
     def activity_poller_for(domain, task_list, lookup)

--- a/lib/cadence/workflow/context.rb
+++ b/lib/cadence/workflow/context.rb
@@ -52,7 +52,7 @@ module Cadence
           task_list: execution_options.task_list,
           retry_policy: execution_options.retry_policy,
           timeouts: execution_options.timeouts,
-          headers: execution_options.headers
+          headers: config.header_propagator_chain.inject(execution_options.headers)
         )
 
         target, cancelation_id = schedule_decision(decision)
@@ -110,7 +110,7 @@ module Cadence
           task_list: execution_options.task_list,
           retry_policy: execution_options.retry_policy,
           timeouts: execution_options.timeouts,
-          headers: execution_options.headers
+          headers: config.header_propagator_chain.inject(execution_options.headers)
         )
 
         target, cancelation_id = schedule_decision(decision)

--- a/spec/unit/lib/cadence/middleware/header_propagator_chain_spec.rb
+++ b/spec/unit/lib/cadence/middleware/header_propagator_chain_spec.rb
@@ -1,0 +1,51 @@
+require 'cadence/middleware/header_propagator_chain'
+require 'cadence/middleware/entry'
+
+describe Cadence::Middleware::HeaderPropagatorChain do
+  class TestHeaderPropagator
+    attr_reader :id
+
+    def initialize(id)
+      @id = id
+    end
+
+    def inject!(header)
+      header['first'] = id unless header.has_key? 'first'
+      header[id] = id
+    end
+  end
+
+  describe '#inject' do
+    subject { described_class.new(propagators) }
+    let(:headers) { { 'test' => 'header' } }
+
+    context 'with propagators' do
+      let(:propagators) do
+        [
+          propagator_1,
+          propagator_2,
+        ]
+      end
+      let(:propagator_1) { Cadence::Middleware::Entry.new(TestHeaderPropagator, '1') }
+      let(:propagator_2) { Cadence::Middleware::Entry.new(TestHeaderPropagator, '2') }
+
+      it 'calls each propagator in order' do
+        expected = {
+          'test' => 'header',
+          'first' => '1',
+          '1' => '1',
+          '2' => '2',
+        }
+        expect(subject.inject(headers)).to eq(expected)
+      end
+    end
+
+    context 'without propagators' do
+      let(:propagators) { [] }
+
+      it 'returns the result of the passed block' do
+        expect(subject.inject(headers)).to eq(headers)
+      end
+    end
+  end
+end

--- a/spec/unit/lib/cadence/workflow/decision_task_processor_spec.rb
+++ b/spec/unit/lib/cadence/workflow/decision_task_processor_spec.rb
@@ -9,7 +9,7 @@ require 'cadence/configuration'
 describe Cadence::Workflow::DecisionTaskProcessor do
   class TestWorkflow < Cadence::Workflow; end
 
-  subject { described_class.new(task, domain, lookup, middleware_chain, config) }
+  subject { described_class.new(task, domain, lookup, middleware_chain, workflow_middleware_chain, config) }
 
   let(:task) { Fabricate(:decision_task_thrift) }
   let(:domain) { 'test-domain' }
@@ -23,6 +23,7 @@ describe Cadence::Workflow::DecisionTaskProcessor do
   end
   let(:metadata) { Cadence::Metadata.generate(Cadence::Metadata::DECISION_TYPE, task, domain) }
   let(:middleware_chain) { Cadence::Middleware::Chain.new }
+  let(:workflow_middleware_chain) { Cadence::Middleware::Chain.new }
   let(:executor) { instance_double(Cadence::Workflow::Executor, run: []) }
   let(:config) { Cadence::Configuration.new }
 
@@ -49,7 +50,7 @@ describe Cadence::Workflow::DecisionTaskProcessor do
 
       allow(Cadence::Workflow::Executor)
         .to receive(:new)
-        .with(TestWorkflow, an_instance_of(Cadence::Workflow::History), metadata, config)
+        .with(TestWorkflow, an_instance_of(Cadence::Workflow::History), metadata, config, workflow_middleware_chain)
         .and_return(executor)
     end
 

--- a/spec/unit/lib/cadence/workflow/executor_spec.rb
+++ b/spec/unit/lib/cadence/workflow/executor_spec.rb
@@ -1,9 +1,10 @@
+require 'cadence/middleware/chain'
 require 'cadence/workflow/executor'
 require 'cadence/workflow/history'
 require 'cadence/workflow'
 
 describe Cadence::Workflow::Executor do
-  subject { described_class.new(workflow, history, decision_metadata, config) }
+  subject { described_class.new(workflow, history, decision_metadata, config, middleware_chain) }
 
   let(:workflow_started_event) { Fabricate(:workflow_execution_started_event_thrift, eventId: 1) }
   let(:history) do
@@ -17,6 +18,7 @@ describe Cadence::Workflow::Executor do
   let(:workflow) { TestWorkflow }
   let(:decision_metadata) { Fabricate(:decision_metadata) }
   let(:config) { Cadence::Configuration.new }
+  let(:middleware_chain) { Cadence::Middleware::Chain.new }
 
   class TestWorkflow < Cadence::Workflow
     def execute
@@ -27,6 +29,7 @@ describe Cadence::Workflow::Executor do
   describe '#run' do
     it 'runs a workflow' do
       allow(workflow).to receive(:execute_in_context).and_call_original
+      expect(middleware_chain).to receive(:invoke).and_call_original
 
       subject.run
 


### PR DESCRIPTION
This change contains the following changes, and closely mirrors https://github.com/coinbase/temporal-ruby/pull/226.

1. Workflow middleware
This is configured on a worker similar to workflow_task and acitvity middleware (worker.add_workflow_middleware(middleware). Workflow middleware gets the workflow metadata which contains headers, and can be used to extract things out of the headers. Activities already have this support via the activity middleware.

2. Header propagation (inject into outgoing headers)
This is configured on the temporal configuration (c.add_header_propagator(propagator)). The propagator is for outgoing headers- so you want to inject into the headers. A propagator is just a class that implements def inject!(header) that modifies header in place and does not return anything.

Tests have been added/amended as necessary.