### PR TITLE
Expose parent workflow info (ID and RunID) in Cadence::Metadata::Workflow object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.18
+- Expose parent workflow info (ID and RunID) in Cadence::Metadata::Workflow object
+
 ## 0.1.17
 - Add workflow decision task deserialization logic that is compatible with official go implementation
 

--- a/lib/cadence/metadata/workflow.rb
+++ b/lib/cadence/metadata/workflow.rb
@@ -3,13 +3,15 @@ require 'cadence/metadata/base'
 module Cadence
   module Metadata
     class Workflow < Base
-      attr_reader :domain, :id, :name, :run_id, :attempt, :headers, :timeouts
+      attr_reader :domain, :id, :name, :run_id, :parent_workflow_id, :parent_workflow_run_id, :attempt, :headers, :timeouts
 
-      def initialize(domain:, id:, name:, run_id:, attempt:, timeouts:, headers: {})
+      def initialize(domain:, id:, name:, run_id:, parent_workflow_id: nil, parent_workflow_run_id: nil, attempt:, timeouts:, headers: {})
         @domain = domain
         @id = id
         @name = name
         @run_id = run_id
+        @parent_workflow_id = parent_workflow_id
+        @parent_workflow_run_id = parent_workflow_run_id
         @attempt = attempt
         @headers = headers
         @timeouts = timeouts
@@ -27,6 +29,8 @@ module Cadence
           workflow_id: id,
           workflow_name: name,
           workflow_run_id: run_id,
+          parent_workflow_id: parent_workflow_id,
+          parent_workflow_run_id: parent_workflow_run_id,
           attempt: attempt
         }
       end

--- a/lib/cadence/version.rb
+++ b/lib/cadence/version.rb
@@ -1,3 +1,3 @@
 module Cadence
-  VERSION = '0.1.17'.freeze
+  VERSION = '0.1.18'.freeze
 end

--- a/lib/cadence/workflow/executor.rb
+++ b/lib/cadence/workflow/executor.rb
@@ -56,6 +56,8 @@ module Cadence
           id: metadata.workflow_id,
           name: event_attributes.workflowType.name,
           run_id: event_attributes.originalExecutionRunId,
+          parent_workflow_id: event_attributes.parentWorkflowExecution&.workflowId,
+          parent_workflow_run_id: event_attributes.parentWorkflowExecution&.runId,
           attempt: event_attributes.attempt,
           headers: event_attributes.header&.fields || {},
           timeouts: {

--- a/spec/fabricators/thrift/history_event_fabricator.rb
+++ b/spec/fabricators/thrift/history_event_fabricator.rb
@@ -26,6 +26,26 @@ Fabricator(:workflow_execution_started_event_thrift, from: :history_event_thrift
   end
 end
 
+Fabricator(:workflow_execution_started_event_thrift_with_parent, from: :history_event_thrift) do
+  eventType { CadenceThrift::EventType::WorkflowExecutionStarted }
+  workflowExecutionStartedEventAttributes do
+    CadenceThrift::WorkflowExecutionStartedEventAttributes.new(
+      workflowType: Fabricate(:workflow_type_thrift),
+      parentWorkflowExecution: Fabricate(:workflow_execution_thrift),
+      taskList: Fabricate(:task_list_thrift),
+      input: nil,
+      executionStartToCloseTimeoutSeconds: 60,
+      taskStartToCloseTimeoutSeconds: 15,
+      originalExecutionRunId: SecureRandom.uuid,
+      identity: 'test-worker@test-host',
+      firstExecutionRunId: SecureRandom.uuid,
+      retryPolicy: nil,
+      attempt: 0,
+      header: Fabricate(:header_thrift)
+    )
+  end
+end
+
 Fabricator(:workflow_execution_completed_event_thrift, from: :history_event_thrift) do
   eventType { CadenceThrift::EventType::WorkflowExecutionCompleted }
   workflowExecutionCompletedEventAttributes do |attrs|

--- a/spec/fabricators/workflow_metadata_fabricator.rb
+++ b/spec/fabricators/workflow_metadata_fabricator.rb
@@ -14,3 +14,20 @@ Fabricator(:workflow_metadata, from: :open_struct) do
     }
   end
 end
+
+Fabricator(:workflow_metadata_with_parent, from: :open_struct) do
+  domain 'test-domain'
+  id { SecureRandom.uuid }
+  name 'TestWorkflow'
+  run_id { SecureRandom.uuid }
+  parent_workflow_id { SecureRandom.uuid }
+  parent_workflow_run_id { SecureRandom.uuid }
+  attempt 1
+  headers { {} }
+  timeouts do
+    {
+      execution: 25,
+      task: 15
+    }
+  end
+end

--- a/spec/unit/lib/cadence/metadata/workflow_spec.rb
+++ b/spec/unit/lib/cadence/metadata/workflow_spec.rb
@@ -15,6 +15,22 @@ describe Cadence::Metadata::Workflow do
       expect(subject.timeouts).to eq(args.timeouts)
     end
 
+    context 'with a parent workflow' do
+      let(:args) { Fabricate(:workflow_metadata_with_parent) }
+
+      it 'sets the attributes' do
+        expect(subject.domain).to eq(args.domain)
+        expect(subject.id).to eq(args.id)
+        expect(subject.name).to eq(args.name)
+        expect(subject.run_id).to eq(args.run_id)
+        expect(subject.parent_workflow_id).to eq(args.parent_workflow_id)
+        expect(subject.parent_workflow_run_id).to eq(args.parent_workflow_run_id)
+        expect(subject.attempt).to eq(args.attempt)
+        expect(subject.headers).to eq(args.headers)
+        expect(subject.timeouts).to eq(args.timeouts)
+      end
+    end
+
     it { is_expected.to be_frozen }
     it { is_expected.not_to be_activity }
     it { is_expected.not_to be_decision }
@@ -28,7 +44,9 @@ describe Cadence::Metadata::Workflow do
         workflow_id: subject.id,
         attempt: subject.attempt,
         workflow_name: subject.name,
-        workflow_run_id: subject.run_id
+        workflow_run_id: subject.run_id,
+        parent_workflow_id: subject.parent_workflow_id,
+        parent_workflow_run_id: subject.parent_workflow_run_id
       )
     end
   end

--- a/spec/unit/lib/cadence/workflow/executor_spec.rb
+++ b/spec/unit/lib/cadence/workflow/executor_spec.rb
@@ -67,6 +67,8 @@ describe Cadence::Workflow::Executor do
           id: decision_metadata.workflow_id,
           name: event_attributes.workflowType.name,
           run_id: event_attributes.originalExecutionRunId,
+          parent_workflow_id: nil,
+          parent_workflow_run_id: nil,
           attempt: event_attributes.attempt,
           headers: { 'Foo' => 'Bar' },
           timeouts: {
@@ -74,6 +76,61 @@ describe Cadence::Workflow::Executor do
             task: event_attributes.taskStartToCloseTimeoutSeconds
           }
         )
+    end
+
+    context 'for a workflow with a parent workflow' do
+      let(:workflow_started_event) { Fabricate(:workflow_execution_started_event_thrift_with_parent, eventId: 1) }
+
+      it 'runs a workflow' do
+        allow(workflow).to receive(:execute_in_context).and_call_original
+        expect(middleware_chain).to receive(:invoke).and_call_original
+
+        subject.run
+
+        expect(workflow)
+          .to have_received(:execute_in_context)
+          .with(
+            an_instance_of(Cadence::Workflow::Context),
+            nil
+          )
+      end
+
+      it 'returns a complete workflow decision' do
+        decisions = subject.run
+
+        expect(decisions.length).to eq(1)
+
+        decision_id, decision = decisions.first
+        expect(decision_id).to eq(history.events.length + 1)
+        expect(decision).to be_an_instance_of(Cadence::Workflow::Decision::CompleteWorkflow)
+        expect(decision.result).to eq('test')
+      end
+
+      it 'generates workflow metadata' do
+        allow(Cadence::Metadata::Workflow).to receive(:new).and_call_original
+        workflow_started_event.workflowExecutionStartedEventAttributes.header =
+          Fabricate(:header_thrift, fields: { 'Foo' => 'Bar' })
+
+        subject.run
+
+        event_attributes = workflow_started_event.workflowExecutionStartedEventAttributes
+        expect(Cadence::Metadata::Workflow)
+          .to have_received(:new)
+          .with(
+            domain: decision_metadata.domain,
+            id: decision_metadata.workflow_id,
+            name: event_attributes.workflowType.name,
+            run_id: event_attributes.originalExecutionRunId,
+            parent_workflow_id: event_attributes.parentWorkflowExecution.workflowId,
+            parent_workflow_run_id: event_attributes.parentWorkflowExecution.runId,
+            attempt: event_attributes.attempt,
+            headers: { 'Foo' => 'Bar' },
+            timeouts: {
+              execution: event_attributes.executionStartToCloseTimeoutSeconds,
+              task: event_attributes.taskStartToCloseTimeoutSeconds
+            }
+          )
+      end
     end
   end
 end


### PR DESCRIPTION
**What changed**
This change exposes the parent workflow info, specifically the workflow id and run id, in the Cadence::Metadata::Workflow object so that it is accessible within a child workflow. This is only present if there is actually a parent workflow, nil otherwise.

For reference, this was added a whiles back to cadence thrift as a property in the `workflowExecutionStartedEventAttributes` event, and then supported in the go and java clients, see https://github.com/uber/cadence/issues/540

**Tests**
This is tested via rspec - existing specs to ensure status quo is unchanged, and new specs .