### PR TITLE
Pass in domain rather than workflow for new method signal workflow execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.19
+- Add a new `#signal_workflow_execution` method to accept domain rather than workflow.
+
 ## 0.1.18
 - Expose parent workflow info (ID and RunID) in Cadence::Metadata::Workflow object
 

--- a/lib/cadence/client.rb
+++ b/lib/cadence/client.rb
@@ -65,9 +65,20 @@ module Cadence
       nil
     end
 
+    # DEPRECATED: Please use signal_workflow_execution instead
     def signal_workflow(workflow, signal, workflow_id, run_id, input = nil)
       connection.signal_workflow_execution(
         domain: workflow.domain, # TODO: allow passing domain instead
+        workflow_id: workflow_id,
+        run_id: run_id,
+        signal: signal,
+        input: input
+      )
+    end
+
+    def signal_workflow_execution(domain:, signal:, workflow_id:, run_id:, input: nil)
+      connection.signal_workflow_execution(
+        domain: domain,
         workflow_id: workflow_id,
         run_id: run_id,
         signal: signal,

--- a/lib/cadence/version.rb
+++ b/lib/cadence/version.rb
@@ -1,3 +1,3 @@
 module Cadence
-  VERSION = '0.1.18'.freeze
+  VERSION = '0.1.19'.freeze
 end

--- a/rbi/cadence-ruby.rbi
+++ b/rbi/cadence-ruby.rbi
@@ -27,6 +27,8 @@ module Cadence
 
   def self.signal_workflow(*args, &block); end
 
+  def self.signal_workflow_execution(*args, &block); end
+
   def self.start_workflow(*args, &block); end
 
   def self.terminate_workflow(*args, &block); end
@@ -456,6 +458,8 @@ class Cadence::Client
   def schedule_workflow(workflow, cron_schedule, *input, **args); end
 
   def signal_workflow(workflow, signal, workflow_id, run_id, input = nil); end
+
+  def signal_workflow_execution(domain:, signal:, workflow_id:, run_id:, input: nil); end
 
   def start_workflow(workflow, *input, **args); end
 

--- a/spec/unit/lib/cadence/client_spec.rb
+++ b/spec/unit/lib/cadence/client_spec.rb
@@ -875,4 +875,28 @@ describe Cadence::Client do
       end
     end
   end
+
+  describe '#signal_workflow_execution' do
+    before do
+      allow(connection).to receive(:signal_workflow_execution).and_return(nil)
+
+      it 'calls connection signal_workflow_execution' do
+        subject.signal_workflow_execution(
+          domain: 'default-test-domain',
+          signal: 'signal-name',
+          workflow_id: 'workflow-id',
+          run_id: 'run-id',
+          input: 'input'
+        )
+
+        expect(connection).to have_received(:signal_workflow_execution).with(
+          domain: 'default-test-domain',
+          workflow_id: 'workflow-id',
+          run_id: 'run-id',
+          signal: 'signal-name',
+          input: 'input'
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
This change modifies the parameter requirement from `workflow` to `domain` in a new method signal_workflow_execution. There is no reason for workflow to be passed in just to get the domain, and the `workflow` object is not accessible from within the workflow.
