### PR TITLE
Check activity id, type and input to detect non-deterministic workflow when applying history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.20
+- Check activity id, type and input to detect non-deterministic workflow when applying history
+
 ## 0.1.19
 - Add a new `#signal_workflow_execution` method to accept domain rather than workflow.
 

--- a/lib/cadence/version.rb
+++ b/lib/cadence/version.rb
@@ -1,3 +1,3 @@
 module Cadence
-  VERSION = '0.1.19'.freeze
+  VERSION = '0.1.20'.freeze
 end

--- a/lib/cadence/workflow/history/event.rb
+++ b/lib/cadence/workflow/history/event.rb
@@ -65,7 +65,7 @@ module Cadence
           case type
           when 'ActivityTaskScheduled'
             {
-              activity_id: attributes.activityId,
+              activity_id: attributes.activityId.to_i, # activityId is a string from thrift
               activity_type: attributes.activityType.name,
               input: deserialize(attributes.input)
             }

--- a/lib/cadence/workflow/history/event.rb
+++ b/lib/cadence/workflow/history/event.rb
@@ -1,9 +1,12 @@
 require 'cadence/utils'
+require 'cadence/concerns/input_deserializer'
 
 module Cadence
   class Workflow
     class History
       class Event
+        include Cadence::Concerns::InputDeserializer
+
         EVENT_TYPES = %w[
           ActivityTaskStarted
           ActivityTaskCompleted
@@ -55,6 +58,19 @@ module Cadence
             attributes.initiatedEventId
           else
             id
+          end
+        end
+
+        def target_attributes
+          case type
+          when 'ActivityTaskScheduled'
+            {
+              activity_id: attributes.activityId,
+              activity_type: attributes.activityType.name,
+              input: deserialize(attributes.input)
+            }
+          else
+            {}
           end
         end
 

--- a/lib/cadence/workflow/history/event_target.rb
+++ b/lib/cadence/workflow/history/event_target.rb
@@ -5,6 +5,7 @@ module Cadence
     class History
       class EventTarget
         class UnexpectedEventType < InternalError; end
+        class UnexpectedDecisionType < InternalError; end
 
         ACTIVITY_TYPE                         = :activity
         CANCEL_ACTIVITY_REQUEST_TYPE          = :cancel_activity_request
@@ -18,7 +19,7 @@ module Cadence
         CANCEL_WORKFLOW_REQUEST_TYPE          = :cancel_workflow_request
 
         # NOTE: The order is important, first prefix match wins (will be a longer match)
-        TARGET_TYPES = {
+        EVENT_TARGET_TYPES = {
           'ActivityTaskCancel'                     => CANCEL_ACTIVITY_REQUEST_TYPE,
           'ActivityTask'                           => ACTIVITY_TYPE,
           'RequestCancelActivityTask'              => CANCEL_ACTIVITY_REQUEST_TYPE,
@@ -37,31 +38,60 @@ module Cadence
           'WorkflowExecution'                      => WORKFLOW_TYPE,
         }.freeze
 
-        attr_reader :id, :type
+        DECISION_TARGET_TYPES = {
+          'Cadence::Workflow::Decision::ScheduleActivity'            => History::EventTarget::ACTIVITY_TYPE,
+          'Cadence::Workflow::Decision::RequestActivityCancellation' => History::EventTarget::CANCEL_ACTIVITY_REQUEST_TYPE,
+          'Cadence::Workflow::Decision::RecordMarker'                => History::EventTarget::MARKER_TYPE,
+          'Cadence::Workflow::Decision::StartTimer'                  => History::EventTarget::TIMER_TYPE,
+          'Cadence::Workflow::Decision::CancelTimer'                 => History::EventTarget::CANCEL_TIMER_REQUEST_TYPE,
+          'Cadence::Workflow::Decision::CompleteWorkflow'            => History::EventTarget::WORKFLOW_TYPE,
+          'Cadence::Workflow::Decision::FailWorkflow'                => History::EventTarget::WORKFLOW_TYPE,
+          'Cadence::Workflow::Decision::StartChildWorkflow'          => History::EventTarget::CHILD_WORKFLOW_TYPE,
+        }.freeze
+
+        DECISION_ATTRIBUTE_LISTS = {
+          'Cadence::Workflow::Decision::ScheduleActivity'            => [:activity_id, :activity_type, :input],
+        }
+
+        attr_reader :id, :type, :attributes
 
         def self.workflow
           @workflow ||= new(1, WORKFLOW_TYPE)
         end
 
         def self.from_event(event)
-          _, target_type = TARGET_TYPES.find { |type, _| event.type.start_with?(type) }
+          _, target_type = EVENT_TARGET_TYPES.find { |type, _| event.type.start_with?(type) }
 
           unless target_type
             raise UnexpectedEventType, "Unexpected event #{event.type}"
           end
 
-          new(event.decision_id, target_type)
+          new(event.decision_id, target_type, attributes: event.target_attributes)
         end
 
-        def initialize(id, type)
+        def self.from_decision(decision_id, decision)
+          decision_type = decision.class.name
+          target_type = DECISION_TARGET_TYPES[decision_type]
+
+          unless target_type
+            raise UnexpectedDecisionType, "Unexpected decision type #{decision_type}"
+          end
+
+          attribute_list = DECISION_ATTRIBUTE_LISTS.fetch(decision_type, [])
+
+          new(decision_id, target_type, attributes: decision.to_h.slice(*attribute_list))
+        end
+
+        def initialize(id, type, attributes: {})
           @id = id
           @type = type
+          @attributes = attributes
 
           freeze
         end
 
         def ==(other)
-          id == other.id && type == other.type
+          id == other.id && type == other.type && attributes == other.attributes
         end
 
         def eql?(other)
@@ -69,11 +99,11 @@ module Cadence
         end
 
         def hash
-          [id, type].hash
+          [id, type, attributes].hash
         end
 
         def to_s
-          "#{type} (#{id})"
+          "#{type}: #{id} (#{attributes})"
         end
       end
     end

--- a/lib/cadence/workflow/history/event_target.rb
+++ b/lib/cadence/workflow/history/event_target.rb
@@ -91,7 +91,7 @@ module Cadence
         end
 
         def ==(other)
-          id == other.id && type == other.type && attributes == other.attributes
+          id == other.id && type == other.type
         end
 
         def eql?(other)
@@ -99,7 +99,7 @@ module Cadence
         end
 
         def hash
-          [id, type, attributes].hash
+          [id, type].hash
         end
 
         def to_s

--- a/lib/cadence/workflow/history/event_target.rb
+++ b/lib/cadence/workflow/history/event_target.rb
@@ -39,14 +39,14 @@ module Cadence
         }.freeze
 
         DECISION_TARGET_TYPES = {
-          'Cadence::Workflow::Decision::ScheduleActivity'            => History::EventTarget::ACTIVITY_TYPE,
-          'Cadence::Workflow::Decision::RequestActivityCancellation' => History::EventTarget::CANCEL_ACTIVITY_REQUEST_TYPE,
-          'Cadence::Workflow::Decision::RecordMarker'                => History::EventTarget::MARKER_TYPE,
-          'Cadence::Workflow::Decision::StartTimer'                  => History::EventTarget::TIMER_TYPE,
-          'Cadence::Workflow::Decision::CancelTimer'                 => History::EventTarget::CANCEL_TIMER_REQUEST_TYPE,
-          'Cadence::Workflow::Decision::CompleteWorkflow'            => History::EventTarget::WORKFLOW_TYPE,
-          'Cadence::Workflow::Decision::FailWorkflow'                => History::EventTarget::WORKFLOW_TYPE,
-          'Cadence::Workflow::Decision::StartChildWorkflow'          => History::EventTarget::CHILD_WORKFLOW_TYPE,
+          'Cadence::Workflow::Decision::ScheduleActivity'            => ACTIVITY_TYPE,
+          'Cadence::Workflow::Decision::RequestActivityCancellation' => CANCEL_ACTIVITY_REQUEST_TYPE,
+          'Cadence::Workflow::Decision::RecordMarker'                => MARKER_TYPE,
+          'Cadence::Workflow::Decision::StartTimer'                  => TIMER_TYPE,
+          'Cadence::Workflow::Decision::CancelTimer'                 => CANCEL_TIMER_REQUEST_TYPE,
+          'Cadence::Workflow::Decision::CompleteWorkflow'            => WORKFLOW_TYPE,
+          'Cadence::Workflow::Decision::FailWorkflow'                => WORKFLOW_TYPE,
+          'Cadence::Workflow::Decision::StartChildWorkflow'          => CHILD_WORKFLOW_TYPE,
         }.freeze
 
         DECISION_ATTRIBUTE_LISTS = {

--- a/lib/cadence/workflow/state_manager.rb
+++ b/lib/cadence/workflow/state_manager.rb
@@ -57,7 +57,7 @@ module Cadence
 
         decisions << [decision_id, decision]
 
-        return [event_target_from(decision_id, decision), cancelation_id]
+        [History::EventTarget.from_decision(decision_id, decision), cancelation_id]
       end
 
       def release?(release_name)
@@ -258,28 +258,6 @@ module Cadence
         end
       end
 
-      def event_target_from(decision_id, decision)
-        target_type =
-          case decision
-          when Decision::ScheduleActivity
-            History::EventTarget::ACTIVITY_TYPE
-          when Decision::RequestActivityCancellation
-            History::EventTarget::CANCEL_ACTIVITY_REQUEST_TYPE
-          when Decision::RecordMarker
-            History::EventTarget::MARKER_TYPE
-          when Decision::StartTimer
-            History::EventTarget::TIMER_TYPE
-          when Decision::CancelTimer
-            History::EventTarget::CANCEL_TIMER_REQUEST_TYPE
-          when Decision::CompleteWorkflow, Decision::FailWorkflow
-            History::EventTarget::WORKFLOW_TYPE
-          when Decision::StartChildWorkflow
-            History::EventTarget::CHILD_WORKFLOW_TYPE
-          end
-
-        History::EventTarget.new(decision_id, target_type)
-      end
-
       def dispatch(target, name, *attributes)
         dispatcher.dispatch(target, name, attributes)
       end
@@ -292,7 +270,7 @@ module Cadence
           raise NonDeterministicWorkflowError, "A decision #{target} was not scheduled upon replay"
         end
 
-        existing_target = event_target_from(existing_decision_id, existing_decision)
+        existing_target = History::EventTarget.from_decision(existing_decision_id, existing_decision)
         if target != existing_target
           raise NonDeterministicWorkflowError, "Unexpected decision #{existing_target} (expected #{target})"
         end

--- a/lib/cadence/workflow/state_manager.rb
+++ b/lib/cadence/workflow/state_manager.rb
@@ -271,7 +271,7 @@ module Cadence
         end
 
         existing_target = History::EventTarget.from_decision(existing_decision_id, existing_decision)
-        if target != existing_target
+        if target != existing_target || target.attributes != existing_target.attributes
           raise NonDeterministicWorkflowError, "Unexpected decision #{existing_target} (expected #{target})"
         end
       end

--- a/spec/fabricators/thrift/history_event_fabricator.rb
+++ b/spec/fabricators/thrift/history_event_fabricator.rb
@@ -95,7 +95,7 @@ Fabricator(:activity_task_scheduled_event_thrift, from: :history_event_thrift) d
   eventType { CadenceThrift::EventType::ActivityTaskScheduled }
   activityTaskScheduledEventAttributes do |attrs|
     CadenceThrift::ActivityTaskScheduledEventAttributes.new(
-      activityId: attrs[:eventId],
+      activityId: attrs[:eventId].to_s,
       activityType: CadenceThrift::ActivityType.new(name: 'TestActivity'),
       input: Cadence::JSON.serialize(attrs[:input]),
       decisionTaskCompletedEventId: attrs[:eventId] - 1,
@@ -145,7 +145,7 @@ Fabricator(:timer_started_event_thrift, from: :history_event_thrift) do
   eventType { CadenceThrift::EventType::TimerStarted }
   timerStartedEventAttributes do |attrs|
     CadenceThrift::TimerStartedEventAttributes.new(
-      timerId: attrs[:eventId],
+      timerId: attrs[:eventId].to_s,
       startToFireTimeoutSeconds: 10,
       decisionTaskCompletedEventId: attrs[:eventId] - 1
     )
@@ -156,7 +156,7 @@ Fabricator(:timer_fired_event_thrift, from: :history_event_thrift) do
   eventType { CadenceThrift::EventType::TimerFired }
   timerFiredEventAttributes do |attrs|
     CadenceThrift::TimerFiredEventAttributes.new(
-      timerId: attrs[:eventId],
+      timerId: attrs[:eventId].to_s,
       startedEventId: attrs[:eventId] - 4
     )
   end
@@ -166,7 +166,7 @@ Fabricator(:timer_canceled_event_thrift, from: :history_event_thrift) do
   eventType { CadenceThrift::EventType::TimerCanceled }
   timerCanceledEventAttributes do |attrs|
     CadenceThrift::TimerCanceledEventAttributes.new(
-      timerId: attrs[:eventId],
+      timerId: attrs[:eventId].to_s,
       startedEventId: attrs[:eventId] - 4,
       decisionTaskCompletedEventId: attrs[:eventId] - 1,
       identity: 'test-worker@test-host'

--- a/spec/unit/lib/cadence/workflow/history/event_spec.rb
+++ b/spec/unit/lib/cadence/workflow/history/event_spec.rb
@@ -41,4 +41,30 @@ describe Cadence::Workflow::History::Event do
       it { is_expected.to eq(raw_event.eventId) }
     end
   end
+
+  describe '#target_attributes' do
+    subject { described_class.new(raw_event).target_attributes }
+
+    context 'when event is ActivityTaskScheduled' do
+      let(:input) { ['foo', 'bar', { 'foo' => 'bar' }] }
+      let(:raw_event) do
+        Fabricate(:activity_task_scheduled_event_thrift, eventId: 42, input: input)
+      end
+
+      it {
+        is_expected.to eq({ activity_id: 42, activity_type: 'TestActivity', input: input })
+      }
+    end
+
+    context 'when event is DecisionTaskScheduled' do
+      let(:input) { ['foo', 'bar', { 'foo' => 'bar' }] }
+      let(:raw_event) do
+        Fabricate(:decision_task_scheduled_event_thrift, eventId: 42)
+      end
+
+      it {
+        is_expected.to eq({})
+      }
+    end
+  end
 end

--- a/spec/unit/lib/cadence/workflow/history/event_target_spec.rb
+++ b/spec/unit/lib/cadence/workflow/history/event_target_spec.rb
@@ -31,7 +31,7 @@ describe Cadence::Workflow::History::EventTarget do
       let(:input) { ['foo', 'bar', { 'foo' => 'bar' }] }
       let(:raw_event) { Fabricate(:activity_task_scheduled_event_thrift, eventId: 42, input: input) }
 
-      it 'sets id and type' do
+      it 'sets id, type and attributes' do
         expect(subject.id).to eq(42)
         expect(subject.type).to eq(described_class::ACTIVITY_TYPE)
         expect(subject.attributes).to eq({ activity_id: 42, activity_type: 'TestActivity', input: input })

--- a/spec/unit/lib/cadence/workflow/history/event_target_spec.rb
+++ b/spec/unit/lib/cadence/workflow/history/event_target_spec.rb
@@ -102,29 +102,5 @@ describe Cadence::Workflow::History::EventTarget do
         expect(subject).to eq(false)
       end
     end
-
-    context 'when attributes are different' do
-      let(:attributes) { { bar: 'foo' } }
-
-      it 'returns false' do
-        expect(subject).to eq(false)
-      end
-    end
-
-    context 'when attributes are subset' do
-      let(:attributes) { {} }
-
-      it 'returns false' do
-        expect(subject).to eq(false)
-      end
-    end
-
-    context 'when attributes are superset' do
-      let(:attributes) { { foo: 'bar', bar: 'foo' } }
-
-      it 'returns false' do
-        expect(subject).to eq(false)
-      end
-    end
   end
 end

--- a/spec/unit/lib/cadence/workflow/history/event_target_spec.rb
+++ b/spec/unit/lib/cadence/workflow/history/event_target_spec.rb
@@ -1,5 +1,6 @@
 require 'cadence/workflow/history/event_target'
 require 'cadence/workflow/history/event'
+require 'cadence/workflow/decision'
 
 describe Cadence::Workflow::History::EventTarget do
   describe '.from_event' do
@@ -7,18 +8,122 @@ describe Cadence::Workflow::History::EventTarget do
     let(:event) { Cadence::Workflow::History::Event.new(raw_event) }
 
     context 'when event is TimerStarted' do
-      let(:raw_event) { Fabricate(:timer_started_event_thrift) }
+      let(:raw_event) { Fabricate(:timer_started_event_thrift, eventId: 42) }
 
-      it 'sets type to timer' do
+      it 'sets id and type' do
+        expect(subject.id).to eq(42)
         expect(subject.type).to eq(described_class::TIMER_TYPE)
+        expect(subject.attributes).to eq({})
       end
     end
 
     context 'when event is TimerCanceled' do
-      let(:raw_event) { Fabricate(:timer_canceled_event_thrift) }
+      let(:raw_event) { Fabricate(:timer_canceled_event_thrift, eventId: 42) }
 
-      it 'sets type to cancel_timer_request' do
+      it 'sets id and type' do
+        expect(subject.id).to eq(42)
         expect(subject.type).to eq(described_class::CANCEL_TIMER_REQUEST_TYPE)
+        expect(subject.attributes).to eq({})
+      end
+    end
+
+    context 'when event is ScheduleActivity' do
+      let(:input) { ['foo', 'bar', { 'foo' => 'bar' }] }
+      let(:raw_event) { Fabricate(:activity_task_scheduled_event_thrift, eventId: 42, input: input) }
+
+      it 'sets id and type' do
+        expect(subject.id).to eq(42)
+        expect(subject.type).to eq(described_class::ACTIVITY_TYPE)
+        expect(subject.attributes).to eq({ activity_id: 42, activity_type: 'TestActivity', input: input })
+      end
+    end
+  end
+
+  describe '.from_decision' do
+    subject { described_class.from_decision(42, decision) }
+
+    context 'when decision is ScheduleActivity' do
+      let(:raw_decision) { { activity_type: 'foo', activity_id: 123, input: ['bar'], domain: 'domain' } }
+      let(:decision) { Cadence::Workflow::Decision::ScheduleActivity.new(**raw_decision) }
+
+      it 'sets id, type' do
+        expect(subject.id).to eq(42)
+        expect(subject.type).to eq(described_class::ACTIVITY_TYPE)
+      end
+
+      it 'sets and slice the attributes' do
+        expect(raw_decision).to include(subject.attributes)
+        expect(subject.attributes.keys).to eq(%i[activity_id activity_type input])
+      end
+    end
+
+    context 'when decision is StartTimer' do
+      let(:raw_decision) { { timeout: 10, timer_id: 123 } }
+      let(:decision) { Cadence::Workflow::Decision::StartTimer.new(**raw_decision) }
+
+      it 'sets id, type' do
+        expect(subject.id).to eq(42)
+        expect(subject.type).to eq(described_class::TIMER_TYPE)
+      end
+
+      it 'sets empty attributes' do
+        expect(subject.attributes.keys).to eq([])
+      end
+    end
+  end
+
+  describe '#==' do
+    subject do
+      described_class.new(id, type, attributes: attributes) ==
+        described_class.new(42, 'type', attributes: { foo: 'bar' })
+    end
+    let(:id) { 42 }
+    let(:type) { 'type' }
+    let(:attributes) { { foo: 'bar' } }
+
+    context 'when all value are the same' do
+      it 'returns true' do
+        expect(subject).to eq(true)
+      end
+    end
+
+    context 'when id are different' do
+      let(:id) { 1 }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when type are different' do
+      let(:type) { 'other_type' }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when attributes are different' do
+      let(:attributes) { { bar: 'foo' } }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when attributes are subset' do
+      let(:attributes) { {} }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
+      end
+    end
+
+    context 'when attributes are superset' do
+      let(:attributes) { { foo: 'bar', bar: 'foo' } }
+
+      it 'returns false' do
+        expect(subject).to eq(false)
       end
     end
   end

--- a/spec/unit/lib/cadence/workflow/state_manager_spec.rb
+++ b/spec/unit/lib/cadence/workflow/state_manager_spec.rb
@@ -1,0 +1,102 @@
+require 'cadence/workflow/state_manager'
+require 'cadence/workflow/decision'
+require 'cadence/workflow/dispatcher'
+require 'cadence/errors'
+
+describe Cadence::Workflow::StateManager do
+  subject { described_class.new(dispatcher) }
+
+  let(:dispatcher) { instance_double(Cadence::Workflow::Dispatcher) }
+
+  describe '.schedule' do
+    it 'appends decision' do
+      expect(subject.decisions.length).to eq(0)
+
+      subject.schedule(Cadence::Workflow::Decision::CompleteWorkflow.new)
+
+      expect(subject.decisions.length).to eq(1)
+    end
+  end
+
+  describe '.apply' do
+    let(:event) { Cadence::Workflow::History::Event.new(raw_event) }
+    let(:window) do
+      window = Cadence::Workflow::History::Window.new
+      window.add(event)
+      window
+    end
+
+    before do
+      allow(window).to receive(:replay?).and_return(true)
+    end
+
+    describe 'ActivityTaskScheduled event' do
+      let(:input) { ['foo', 'bar', { 'foo' => 'bar' }] }
+      let(:raw_event) { Fabricate(:activity_task_scheduled_event_thrift, eventId: 1, input: input) }
+
+      before do
+        subject.schedule(decision)
+      end
+
+      context 'event matchs previous decision' do
+        let(:decision) do
+          Cadence::Workflow::Decision::ScheduleActivity.new(
+            activity_type: 'TestActivity',
+            activity_id: 1,
+            input: input
+          )
+        end
+
+        it 'applies' do
+          expect(subject.decisions.length).to eq(1)
+
+          subject.apply(window)
+
+          expect(subject.decisions.length).to eq(0)
+        end
+      end
+
+      context 'event does not matchs previous decision activity name' do
+        let(:decision) do
+          Cadence::Workflow::Decision::ScheduleActivity.new(
+            activity_type: 'AnotherTestActivity',
+            activity_id: 1,
+            input: input
+          )
+        end
+
+        it 'raises NonDeterministicWorkflowError' do
+          expect { subject.apply(window) }.to raise_error(Cadence::NonDeterministicWorkflowError)
+        end
+      end
+
+      context 'event does not matchs previous decision activity id' do
+        let(:decision) do
+          Cadence::Workflow::Decision::ScheduleActivity.new(
+            activity_type: 'TestActivity',
+            activity_id: 2,
+            input: input
+          )
+        end
+
+        it 'raises NonDeterministicWorkflowError' do
+          expect { subject.apply(window) }.to raise_error(Cadence::NonDeterministicWorkflowError)
+        end
+      end
+
+      context 'event does not matchs previous decision activity input' do
+        let(:decision) do
+          Cadence::Workflow::Decision::ScheduleActivity.new(
+            activity_type: 'TestActivity',
+            activity_id: 1,
+            input: ['foo', 'bar', { 'foo' => 'foo' }]
+          )
+        end
+
+        it 'raises NonDeterministicWorkflowError' do
+          expect { subject.apply(window) }.to raise_error(Cadence::NonDeterministicWorkflowError)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Why**
* `StateManager` verify a workflow determinism by comparing the `EventTarget` from history events and the one generated from workflow logic. 
* `EventTarget` only contains `decision_id` and `type`
    * `type` differentiates whether the decision is for scheduling an activity or fire a timer. 
    * It does not contain extra attributes like activity type and inputs. 
* As a result, `StateManager` cannot detect indeterminism between two different activities. 

**Whats Changed**
* Consolidate `EventTarget` construction logics to the same file. 
* Include activity id, type and input attributes as part of the `EventTarget` equality. 
* If the `EventTarget` from history event is different from the `EventTarget` from the current decision, `StateManager` raise `NonDeterministicWorkflowError`. 

**Testing**
- [x] spec for `EventTarget`
- [x] spec for `StateManager`
- [ ] dev testing
