### PR TITLE
Run basic specs in a github actions workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  test_gem:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.6
+          bundler-cache: true
+
+      - name: Run tests
+        run: |
+          bundle exec rspec

--- a/spec/unit/lib/cadence/crew_spec.rb
+++ b/spec/unit/lib/cadence/crew_spec.rb
@@ -35,7 +35,10 @@ describe Cadence::Crew do
       let(:thread_sync_delay) { 2 }
 
       before do
-        @thread = Thread.new { real_crew.dispatch }
+        @thread = Thread.new do
+          @worker_pid = Process.pid
+          real_crew.dispatch
+        end
         sleep 0.1 # give crew time to start
       end
 
@@ -52,14 +55,14 @@ describe Cadence::Crew do
       end
 
       it 'traps TERM signal' do
-        Process.kill('TERM', 0)
+        Process.kill('TERM', @worker_pid)
         sleep thread_sync_delay
 
         expect(@thread).not_to be_alive
       end
 
       it 'traps INT signal' do
-        Process.kill('INT', 0)
+        Process.kill('INT', @worker_pid)
         sleep thread_sync_delay
 
         expect(@thread).not_to be_alive

--- a/spec/unit/lib/cadence/worker_spec.rb
+++ b/spec/unit/lib/cadence/worker_spec.rb
@@ -260,7 +260,10 @@ describe Cadence::Worker do
 
     describe 'signal handling' do
       before do
-        @thread = Thread.new { subject.start }
+        @thread = Thread.new do
+          @worker_pid = Process.pid
+          subject.start
+        end
         sleep THREAD_SYNC_DELAY # give worker time to start
       end
 
@@ -277,14 +280,14 @@ describe Cadence::Worker do
       end
 
       it 'traps TERM signal' do
-        Process.kill('TERM', 0)
+        Process.kill('TERM', @worker_pid)
         sleep THREAD_SYNC_DELAY
 
         expect(@thread).not_to be_alive
       end
 
       it 'traps INT signal' do
-        Process.kill('INT', 0)
+        Process.kill('TERM', @worker_pid)
         sleep THREAD_SYNC_DELAY
 
         expect(@thread).not_to be_alive


### PR DESCRIPTION
This runs our basic (unit) specs in a github actions workflow for all PRs.

Our CircleCI integration broke a while ago and tests were no longer running in PRs. 

I haven't gotten the examples (integration) specs working yet, they seem to be broken locally and in github actions, so they aren't included in this PR.