### PR TITLE
Add workflow id and activity id to workflow and activity logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.21
+- Add workflow id and activity id to workflow and activity logs
+
 ## 0.1.20
 - Check activity id, type and input to detect non-deterministic workflow when applying history
 

--- a/lib/cadence/activity/task_processor.rb
+++ b/lib/cadence/activity/task_processor.rb
@@ -15,7 +15,10 @@ module Cadence
         @domain = domain
         @metadata = Metadata.generate(Metadata::ACTIVITY_TYPE, task, domain)
         @task_token = task.taskToken
+        @workflow_name = task.workflowType.name
+        @workflow_id = task.workflowExecution.workflowId
         @activity_name = task.activityType.name
+        @activity_id = task.activityId
         @activity_class = activity_lookup.find(activity_name)
         @middleware_chain = middleware_chain
         @config = config
@@ -24,7 +27,7 @@ module Cadence
       def process
         start_time = Time.now
 
-        Cadence.logger.info("Processing activity task for #{activity_name}")
+        Cadence.logger.info("Processing activity task for #{activity_log_name}")
         Cadence.metrics.timing('activity_task.queue_time', queue_time_ms, activity: activity_name)
 
         if !activity_class
@@ -44,7 +47,7 @@ module Cadence
         respond_failed(error.class.name, error.message)
         Cadence::ErrorHandler.handle(error, metadata: metadata)
       rescue Exception => error
-        Cadence.logger.fatal("Activity #{activity_name} unexpectedly failed with: #{error.inspect}")
+        Cadence.logger.fatal("Activity #{activity_log_name} unexpectedly failed with: #{error.inspect}")
         Cadence.logger.debug(error.backtrace.join("\n"))
         Cadence::ErrorHandler.handle(error, metadata: metadata)
         raise
@@ -56,8 +59,8 @@ module Cadence
 
       private
 
-      attr_reader :task, :domain, :task_token, :activity_name, :activity_class,
-        :middleware_chain, :config, :metadata
+      attr_reader :task, :domain, :task_token, :workflow_name, :workflow_id, 
+        :activity_name, :activity_id, :activity_class, :middleware_chain, :config, :metadata
 
       def connection
         @connection ||= Cadence::Connection.generate(config.for_connection)
@@ -68,19 +71,23 @@ module Cadence
       end
 
       def respond_completed(result)
-        Cadence.logger.info("Activity #{activity_name} completed")
+        Cadence.logger.info("Activity #{activity_log_name} completed")
         connection.respond_activity_task_completed(task_token: task_token, result: result)
       rescue StandardError => error
-        Cadence.logger.error("Unable to complete Activity #{activity_name}: #{error.inspect}")
+        Cadence.logger.error("Unable to complete Activity #{activity_log_name}: #{error.inspect}")
         Cadence::ErrorHandler.handle(error, metadata: metadata)
       end
 
       def respond_failed(reason, details)
-        Cadence.logger.error("Activity #{activity_name} failed with: #{reason}")
+        Cadence.logger.error("Activity #{activity_log_name} failed with: #{reason}")
         connection.respond_activity_task_failed(task_token: task_token, reason: reason, details: details)
       rescue StandardError => error
-        Cadence.logger.error("Unable to fail Activity #{activity_name}: #{error.inspect}")
+        Cadence.logger.error("Unable to fail Activity #{activity_log_name}: #{error.inspect}")
         Cadence::ErrorHandler.handle(error, metadata: metadata)
+      end
+
+      def activity_log_name
+        "#{activity_name} (#{activity_id}) of #{workflow_name} (#{workflow_id})"
       end
     end
   end

--- a/lib/cadence/version.rb
+++ b/lib/cadence/version.rb
@@ -1,3 +1,3 @@
 module Cadence
-  VERSION = '0.1.20'.freeze
+  VERSION = '0.1.21'.freeze
 end

--- a/spec/unit/lib/cadence/workflow/decision_task_processor_spec.rb
+++ b/spec/unit/lib/cadence/workflow/decision_task_processor_spec.rb
@@ -152,7 +152,7 @@ describe Cadence::Workflow::DecisionTaskProcessor do
 
         expect(Cadence.logger)
           .to have_received(:error)
-          .with("Unable to complete Decision task TestWorkflow: #<StandardError: Host unreachable>")
+          .with("Unable to complete Decision task for TestWorkflow (#{task.workflowExecution.workflowId}): #<StandardError: Host unreachable>")
       end
 
       it 'calls error handlers' do


### PR DESCRIPTION
**Why**

The current Cadence logs do not identify the exact instance of workflow and activity that's being processed or raising exceptions. Diagnostic and remediation based on these logs are hard. 

**What's changed**
* Add `workflow_id` to info and above logs in `Cadence::Workflow::DecisionTaskProcessor`
* Add `activity_id`, `workflow_name` and `workflow_id` to info and above logs in `Cadence::Activity::TaskProcessor`

**Testing**
- [x] spec