### PR TITLE
Fixes for ruby 3 compatibility

### DIFF
--- a/lib/cadence/saga/saga.rb
+++ b/lib/cadence/saga/saga.rb
@@ -6,13 +6,13 @@ module Cadence
         @compensations = []
       end
 
-      def add_compensation(activity, *args)
-        compensations << [activity, args]
+      def add_compensation(activity, *args, **kwargs)
+        compensations << [activity, args, kwargs]
       end
 
       def compensate
-        compensations.reverse_each do |(activity, args)|
-          context.execute_activity!(activity, *args)
+        compensations.reverse_each do |(activity, args, kwargs)|
+          context.execute_activity!(activity, *args, **kwargs)
         end
       end
 

--- a/rbi/cadence-ruby.rbi
+++ b/rbi/cadence-ruby.rbi
@@ -492,7 +492,7 @@ module Cadence::Saga
 end
 
 class Cadence::Saga::Saga
-  def add_compensation(activity, *args); end
+  def add_compensation(activity, *args, **kwargs); end
 
   def compensate; end
 

--- a/spec/unit/lib/cadence/saga/concern_spec.rb
+++ b/spec/unit/lib/cadence/saga/concern_spec.rb
@@ -29,7 +29,7 @@ describe Cadence::Saga::Concern do
     expect(TestSagaConcernActivity3).to have_received(:execute!).ordered
     expect(context)
       .to have_received(:execute_activity!)
-      .with(TestSagaConcernActivity2, 42).ordered
+      .with(TestSagaConcernActivity2, 42, {}).ordered
   end
 
   def expect_saga_not_to_be_compensated

--- a/spec/unit/lib/cadence/saga/saga_spec.rb
+++ b/spec/unit/lib/cadence/saga/saga_spec.rb
@@ -14,13 +14,13 @@ describe Cadence::Saga::Saga do
       subject.add_compensation('SomeActivity', 42, options: { domain: 'test', task_list: 'test' })
 
       expect(compensations)
-        .to eq([['SomeActivity', [42, options: { domain: 'test', task_list: 'test' }]]])
+        .to eq([['SomeActivity', [42], options: { domain: 'test', task_list: 'test' }]])
     end
 
     it 'adds activity by class' do
       subject.add_compensation(TestSagaActivity, 42)
 
-      expect(compensations).to eq([[TestSagaActivity, [42]]])
+      expect(compensations).to eq([[TestSagaActivity, [42], {}]])
     end
   end
 
@@ -46,13 +46,13 @@ describe Cadence::Saga::Saga do
 
         expect(context)
           .to have_received(:execute_activity!)
-          .with('SomeActivity', 42, options: { domain: 'test', task_list: 'test' })
-          .ordered
+                .with('SomeActivity', 42, options: { domain: 'test', task_list: 'test' })
+                .ordered
 
         expect(context)
           .to have_received(:execute_activity!)
-          .with(TestSagaActivity, 42)
-          .ordered
+                .with(TestSagaActivity, 42, {})
+                .ordered
       end
     end
   end


### PR DESCRIPTION
More fixes for ruby3 compatibility. I missed these in https://github.com/coinbase/cadence-ruby/pull/91.