### PR TITLE
Add WorkflowAlreadyCompletingError to the rbi file

### DIFF
--- a/rbi/cadence-ruby.rbi
+++ b/rbi/cadence-ruby.rbi
@@ -182,6 +182,9 @@ end
 class Cadence::ActivityException < Cadence::ClientError
 end
 
+class Cadence::WorkflowAlreadyCompletingError < Cadence::InternalError
+end
+
 class Anonymous_Struct_608 < Struct
   def backoff; end
 


### PR DESCRIPTION
Add WorkflowAlreadyCompletingError to the rbi file - followup from https://github.com/coinbase/cadence-ruby/pull/93